### PR TITLE
Configure so emails are sent when a build fails…

### DIFF
--- a/jenkins-dsl/cassandra_job_dsl_seed.groovy
+++ b/jenkins-dsl/cassandra_job_dsl_seed.groovy
@@ -105,6 +105,27 @@ job('Cassandra-template-artifacts') {
             javadocDir 'build/javadoc'
             keepAll false
         }
+        extendedEmail {
+            recipientList('builds@cassandra.apache.org')
+            triggers {
+                failure {
+                    sendTo {
+                        recipientList()
+                        developers()
+                        requester()
+                        culprits()
+                    }
+                }
+                fixed {
+                    sendTo {
+                        recipientList()
+                        developers()
+                        requester()
+                        culprits()
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
**I have no idea how to test or deploy this change.**

(This change was manually done to the `*-artifacts` jobs.)

---
Configure so emails are sent when a build fails, becomes unstable or returns to stable, to the builds@ ML and the authors of the breakage.

ref:
 - https://lists.apache.org/thread.html/e170de03f9b89e4dff06a5f524c7fb0ede6790f9f08c75aa50320889@<dev.cassandra.apache.org>
 - https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.extendedEmail