### PR TITLE
updated to debian buster

### DIFF
--- a/docker/jessie-image.docker
+++ b/docker/jessie-image.docker
@@ -1,10 +1,10 @@
-FROM debian:jessie-backports
+FROM debian:buster
 
 ENV DEB_DIST_DIR=/dist
 ENV BUILD_HOME=/home/build
 ENV CASSANDRA_DIR=$BUILD_HOME/cassandra
 
-LABEL org.cassandra.buildenv=jessie
+LABEL org.cassandra.buildenv=buster
 
 VOLUME ${DEB_DIST_DIR}
 
@@ -15,15 +15,14 @@ RUN apt-get update && apt-get -y install \
    curl \
    devscripts \
    git \
-   sudo
-
-RUN apt-get -y -t jessie-backports --no-install-recommends install \
-   openjdk-7-jdk \
-   openjdk-8-jdk
-
-RUN apt-get -y -t jessie-backports install \
+   sudo \
    python-sphinx \
    python-sphinx-rtd-theme
+
+RUN echo 'deb http://ftp.us.debian.org/debian sid main' >> /etc/apt/sources.list
+RUN apt-get update
+
+RUN apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-11-jdk
 
 RUN update-java-alternatives --set java-1.8.0-openjdk-amd64
 


### PR DESCRIPTION
@mshuler @michaelsembwever 

I followed the readme but as of now it is unusable because there is not jessie backports anymore (1) and update / installation of debs fails on that (2)

I ve just updated it to buster and added sid repo so we have java 8 too (buster does not have java 8 anymore).

Do not take me wrong but I am not sure what is the recommened way to build custom debs as of now. The way of doing that by means this PR fixes does not work until now so I am curious how is one supposed to build custom debs then? Jenkins is building only bin and src artifacts (seems like that) and I do not think one should follow (3) just to produce debs, or should he?

(1) https://deb.debian.org/debian/dists/
(2) https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository
(3) https://cassandra.apache.org/doc/latest/development/release_process.html