### PR TITLE
Add Ubuntu 19.10 with JDK11 Image

### DIFF
--- a/docker/testing/ubuntu1810_j11.docker
+++ b/docker/testing/ubuntu1810_j11.docker
@@ -81,7 +81,7 @@ RUN echo 'export ANT_HOME=/usr/share/ant' >> /home/cassandra/.bashrc && \
     echo 'export JAVA_HOME=$JAVA8_HOME' >> /home/cassandra/.bashrc
 
 # run pip commands and setup virtualenv (note we do this after we switch to cassandra user so we
-# setup the virtualenv for the cassandrauser and not the root user by acident)
+# setup the virtualenv for the cassandra user and not the root user by accident)
 RUN virtualenv --python=python3.6 --no-site-packages env
 RUN chmod +x env/bin/activate
 RUN /bin/bash -c "source ~/env/bin/activate && pip3 install Cython && pip3 install -r /opt/requirements.txt && pip3 freeze --user"

--- a/docker/testing/ubuntu18_j11.docker
+++ b/docker/testing/ubuntu18_j11.docker
@@ -81,7 +81,7 @@ RUN echo 'export ANT_HOME=/usr/share/ant' >> /home/cassandra/.bashrc && \
     echo 'export JAVA_HOME=$JAVA8_HOME' >> /home/cassandra/.bashrc
 
 # run pip commands and setup virtualenv (note we do this after we switch to cassandra user so we
-# setup the virtualenv for the cassandrauser and not the root user by acident)
+# setup the virtualenv for the cassandra user and not the root user by accident)
 RUN virtualenv --python=python3.6 --no-site-packages env
 RUN chmod +x env/bin/activate
 RUN /bin/bash -c "source ~/env/bin/activate && pip3 install Cython && pip3 install -r /opt/requirements.txt && pip3 freeze --user"

--- a/docker/testing/ubuntu1910_j11.docker
+++ b/docker/testing/ubuntu1910_j11.docker
@@ -1,0 +1,127 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:19.10
+MAINTAINER Eduard Tudenhoefner <etudenhoefner@gmail.com>
+
+# install our python dependencies and some other stuff we need
+# libev4 libev-dev are for the python driver / libssl-dev is for python3.6
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common apt-utils vim
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y git-core python2.7 python3-pip python3.8 python3.8-venv python3.8-dev net-tools libev4 libev-dev wget gcc libssl-dev
+
+# need to install Python 3.6 as well
+RUN cd /opt && wget https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tgz && \
+    tar xzf Python-3.6.10.tgz && cd Python-3.6.10 && \
+    ./configure --enable-optimizations && \
+    make altinstall && \
+    cp /opt/Python-3.6.10/python /usr/bin/python3.6
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 2
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 3
+RUN python3.6 -m pip install --upgrade pip
+RUN python3.7 -m pip install --upgrade pip
+RUN python3.8 -m pip install --upgrade pip
+
+# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+
+# install dumb-init as minimal init system
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y dumb-init
+
+# generate locales for the standard en_US.UTF8 value we use for testing
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y locales && \
+    locale-gen en_US.UTF-8
+
+# as we only need the requirements.txt file from the dtest repo, let's just get it from GitHub as a raw asset
+# so we can avoid needing to clone the entire repo just to get this file
+ADD https://raw.githubusercontent.com/apache/cassandra-dtest/master/requirements.txt /opt
+RUN chmod 0644 /opt/requirements.txt
+
+# now setup python via virtualenv with all of the python dependencies we need according to requirements.txt
+RUN pip3 install virtualenv
+RUN pip3 install --upgrade wheel
+
+# openjdk + ant
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-11-jdk ant ant-optional
+
+# make Java 8 the default executable (we use to run all tests against Java 8)
+RUN update-java-alternatives -s java-1.8.0-openjdk-amd64
+
+# setup our user -- if we don't do this docker will default to root and Cassandra will fail to start
+# as we appear to have a check that the user isn't starting Cassandra as root
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install sudo && \
+    adduser --disabled-password --gecos "" cassandra && \
+    echo "cassandra ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/cassandra && \
+    chmod 0440 /etc/sudoers.d/cassandra
+
+# fix up permissions on the cassandra home dir
+RUN chown -R cassandra:cassandra /home/cassandra
+
+# switch to the cassandra user... we are all done running things as root
+USER cassandra
+ENV HOME /home/cassandra
+WORKDIR /home/cassandra
+
+# Add environment variables for Ant and Java and add them to the PATH
+RUN echo 'export ANT_HOME=/usr/share/ant' >> /home/cassandra/.bashrc && \
+    echo 'export JAVA8_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> /home/cassandra/.bashrc && \
+    echo 'export JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64' >> /home/cassandra/.bashrc && \
+    echo 'export JAVA_HOME=$JAVA8_HOME' >> /home/cassandra/.bashrc
+
+# run pip commands and setup virtualenv (note we do this after we switch to cassandra user so we
+# setup the virtualenv for the cassandra user and not the root user by accident) for Python 3.6/3.7/3.8
+RUN virtualenv --python=python3.6 env3.6
+RUN chmod +x env3.6/bin/activate
+RUN /bin/bash -c "source ~/env3.6/bin/activate && pip3 install Cython && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
+
+RUN virtualenv --python=python3.7 env3.7
+RUN chmod +x env3.7/bin/activate
+RUN /bin/bash -c "source ~/env3.7/bin/activate && pip3 install Cython && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
+
+RUN virtualenv --python=python3.8 env3.8
+RUN chmod +x env3.8/bin/activate
+RUN /bin/bash -c "source ~/env3.8/bin/activate && pip3 install Cython && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
+
+# we need to make SSH less strict to prevent various dtests from failing when they attempt to
+# git clone a given commit/tag/etc
+# upgrading node1 to github:apache/18cdd391ec27d16daf775f928902f5a421c415e3
+# git@github.com:apache/cassandra.git github:apache/18cdd391ec27d16daf775f928902f5a421c415e3
+# 23:47:08,993 ccm INFO Cloning Cassandra...
+# The authenticity of host 'github.com (192.30.253.112)' can't be established.
+# RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
+# Are you sure you want to continue connecting (yes/no)?
+RUN mkdir ~/.ssh
+RUN echo 'Host *\n UserKnownHostsFile /dev/null\n StrictHostKeyChecking no' > ~/.ssh/config
+RUN chown cassandra:cassandra ~/.ssh
+RUN chown cassandra:cassandra ~/.ssh/config
+RUN chmod 600 ~/.ssh/config
+
+# mark "/tmp" as a volume so it will get mounted as an ext4 mount and not
+# the stupid aufs/CoW stuff that the actual docker container mounts will have.
+# we've been seeing 3+ minute hangs when calling sync on an aufs backed mount
+# so it greatly makes tests flaky as things can hang basically anywhere
+VOLUME ["/tmp"]

--- a/docker/testing/ubuntu1910_j11_w_dependencies.docker
+++ b/docker/testing/ubuntu1910_j11_w_dependencies.docker
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# base things off the testing image without dependencies warmed up
+FROM nastra/cassandra-testing-ubuntu1910-java11
+MAINTAINER Eduard Tudenhoefner <etudenhoefner@gmail.com>
+
+USER cassandra
+ENV HOME /home/cassandra
+WORKDIR /home/cassandra
+
+# Fetch the maven dependencies in advance since this tends to fail at runtime
+ARG CASSANDRA_GIT_URL=https://gitbox.apache.org/repos/asf/cassandra.git
+RUN /bin/bash -c "git clone ${CASSANDRA_GIT_URL} ~/cassandra && \
+    cd ~/cassandra && ant maven-ant-tasks-retrieve-build && \
+    git checkout origin/cassandra-3.11 && ant maven-ant-tasks-retrieve-build && \
+    git checkout origin/cassandra-3.0 && ant maven-ant-tasks-retrieve-build && \
+    git checkout origin/cassandra-2.2 && ant maven-ant-tasks-retrieve-build && \
+    git checkout origin/cassandra-2.1 && ant maven-ant-tasks-retrieve-build && \
+    rm -fr ~/cassandra"
+
+# Initialize the CCM git repo as well as this also can fail to clone
+RUN /bin/bash -c "source ~/env3.6/bin/activate && \
+    ccm create -n 1 -v git:trunk test && ccm remove test && \
+    ccm create -n 1 -v git:cassandra-3.11 test && ccm remove test && \
+    ccm create -n 1 -v git:cassandra-3.0 test && ccm remove test && \
+    ccm create -n 1 -v git:cassandra-2.2 test && ccm remove test && \
+    ccm create -n 1 -v git:cassandra-2.1 test && ccm remove test"


### PR DESCRIPTION
This image includes Python 3.6+3.7+3.8 installations in case C* wants to
perform testing with multiple Python versions.