### PR TITLE
added Docker image for Debian Buster

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@
    ```docker build -t cass-build-rpms -f docker/centos7-image.docker docker/```
    The image will contain a clone of the Apache git repository by default. Using a different repository is possible by adding the `--build-arg CASSANDRA_GIT_URL=https://github.com/myuser/cassandra.git` parameter. All successive builds will be executed based on the repository cloned during docker image creation.
 2. Run build script through docker (specify branch, e.g. cassandra-3.0 and version, e.g. 3.0.11):
-   * Debian:
+   * Debian Jessie:
     ```docker run --rm -v `pwd`/dist:/dist `docker images -f label=org.cassandra.buildenv=jessie -q` /home/build/build-debs.sh <branch/tag>```
+   * Debian Buster
+    ```docker run --rm -v `pwd`/dist:/dist `docker images -f label=org.cassandra.buildenv=buster -q` /home/build/build-debs.sh <branch/tag>```
    * RPM:
     ```docker run --rm -v `pwd`/dist:/dist `docker images -f label=org.cassandra.buildenv=centos -q` /home/build/build-rpms.sh <branch/tag>```
+
+For the build by Debian Buster, you have the possibility to build Cassandra either by Java 8 (default) or by Java 11. You control the Java version like following. If you want to build with Java 8, just omit that last option.
+
+```docker run --rm -v `pwd`/dist:/dist `docker images -f label=org.cassandra.buildenv=buster -q` /home/build/build-debs.sh <branch/tag> 11```
 
 You should find newly created Debian and RPM packages in the `dist` directory.
 

--- a/docker/buster-image.docker
+++ b/docker/buster-image.docker
@@ -1,0 +1,42 @@
+FROM debian:buster
+
+ENV DEB_DIST_DIR=/dist
+ENV BUILD_HOME=/home/build
+ENV CASSANDRA_DIR=$BUILD_HOME/cassandra
+
+LABEL org.cassandra.buildenv=buster
+
+VOLUME ${DEB_DIST_DIR}
+
+# install deps
+RUN apt-get update && apt-get -y install \
+   ant \
+   build-essential \
+   curl \
+   devscripts \
+   git \
+   sudo \
+   python-sphinx \
+   python-sphinx-rtd-theme
+
+RUN echo 'deb http://ftp.debian.org/debian stretch main' >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-11-jdk \
+    && sed -i '$d' /etc/apt/sources.list \
+    && apt-get update \
+    && update-java-alternatives --set java-1.8.0-openjdk-amd64
+
+# create and change to build user
+RUN adduser --disabled-login --gecos build build && gpasswd -a build sudo
+RUN echo "build ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/build && \
+   chmod 0440 /etc/sudoers.d/build
+
+USER build
+
+# clone Cassandra and cache maven artifacts
+ARG CASSANDRA_GIT_URL=https://gitbox.apache.org/repos/asf/cassandra.git
+RUN git clone ${CASSANDRA_GIT_URL} ${CASSANDRA_DIR}
+WORKDIR ${CASSANDRA_DIR}
+RUN ant maven-ant-tasks-retrieve-build
+
+COPY build-debs.sh $BUILD_HOME/


### PR DESCRIPTION
@michaelsembwever I ve created Buster Docker file as you suggested.

Do you think we should make this in such way that it is possible to build it either with Java 8 or Java 11 via some build args? I _think_ that debs are compiled with Java 8 in mind in the first place but having this possibility would be nice. 