### PR TITLE
dtest build scripts remove "--no-site-packages" flag and set tmp directory

### DIFF
--- a/build-scripts/cassandra-dtest-pytest.sh
+++ b/build-scripts/cassandra-dtest-pytest.sh
@@ -20,6 +20,7 @@ export NUM_TOKENS="32"
 export CASSANDRA_DIR=${WORKSPACE}
 #Have Cassandra skip all fsyncs to improve test performance and reliability
 export CASSANDRA_SKIP_SYNC=true
+export TMPDIR="./tmp"
 
 # set JAVA_HOME environment to enable multi-version jar files for >4.0
 # both JAVA8/11_HOME env variables must exist
@@ -49,7 +50,7 @@ fi
 
 # Set up venv with dtest dependencies
 set -e # enable immediate exit if venv setup fails
-virtualenv --python=python3 --no-site-packages venv
+virtualenv --python=python3 venv
 source venv/bin/activate
 pip3 install -r cassandra-dtest/requirements.txt
 pip3 freeze
@@ -62,6 +63,7 @@ pip3 freeze
 
 cd cassandra-dtest/
 rm -r upgrade_tests/ # TEMP: remove upgrade_tests - we have no dual JDK installation
+mkdir -p ${TMPDIR}
 set +e # disable immediate exit from this point
 if [ "${DTEST_TARGET}" = "dtest" ]; then
     pytest -vv --log-level="INFO" --use-vnodes --num-tokens=32 --junit-xml=nosetests.xml -s --cassandra-dir=$CASSANDRA_DIR --skip-resource-intensive-tests 2>&1 | tee -a ${WORKSPACE}/test_stdout.txt

--- a/build-scripts/cassandra-dtest.sh
+++ b/build-scripts/cassandra-dtest.sh
@@ -18,6 +18,7 @@ export CCM_HEAP_NEWSIZE="200M"
 export CCM_CONFIG_DIR=${WORKSPACE}/.ccm
 export NUM_TOKENS="32"
 export CASSANDRA_DIR=${WORKSPACE}
+export TMPDIR="./tmp"
 
 # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
 for x in $(seq 1 3); do
@@ -35,7 +36,7 @@ fi
 
 # Set up venv with dtest dependencies
 set -e # enable immediate exit if venv setup fails
-virtualenv --python=python2 --no-site-packages venv
+virtualenv --python=python2 venv
 source venv/bin/activate
 pip install -r cassandra-dtest/requirements.txt
 pip freeze
@@ -48,6 +49,7 @@ pip freeze
 
 cd cassandra-dtest/
 rm -r upgrade_tests/ # TEMP: remove upgrade_tests - we have no dual JDK installation
+mkdir -p ${TMPDIR}
 set +e # disable immediate exit from this point
 if [ "${DTEST_TARGET}" = "dtest" ]; then
     ./run_dtests.py --vnodes true --nose-options="--verbosity=3 --with-xunit --nocapture --attr=!resource-intensive" | tee -a ${WORKSPACE}/test_stdout.txt

--- a/build-scripts/cassandra-test.sh
+++ b/build-scripts/cassandra-test.sh
@@ -27,28 +27,29 @@ _main() {
   fi
 
   ant clean jar
+  mkdir -p tmp
 
   case $target in
     "stress-test" | "fqltool-test")
-      ant $target || echo "failed $target"
+      ant $target -Dtmp.dir="./tmp" || echo "failed $target"
       ;;
     "test")
-      ant testclasslist -Dtest.classlistfile=<( _list_tests "unit" ) || echo "failed $target"
+      ant testclasslist -Dtest.classlistfile=<( _list_tests "unit" ) -Dtmp.dir="./tmp" || echo "failed $target"
       ;;
     "test-cdc")
-      ant testclasslist-cdc -Dtest.classlistfile=<( _list_tests "unit" ) || echo "failed $target"
+      ant testclasslist-cdc -Dtest.classlistfile=<( _list_tests "unit" ) -Dtmp.dir="./tmp" || echo "failed $target"
       ;;
     "test-compression")
-      ant testclasslist-compression -Dtest.classlistfile=<( _list_tests "unit" ) || echo "failed $target"
+      ant testclasslist-compression -Dtest.classlistfile=<( _list_tests "unit" ) -Dtmp.dir="./tmp" || echo "failed $target"
       ;;
     "test-burn")
-      ant testclasslist -Dtest.classlistprefix=burn -Dtest.timeout=$(_timeout_for "test.burn.timeout") -Dtest.classlistfile=<( _list_tests "burn" ) || echo "failed $target"
+      ant testclasslist -Dtest.classlistprefix=burn -Dtest.timeout=$(_timeout_for "test.burn.timeout") -Dtest.classlistfile=<( _list_tests "burn" ) -Dtmp.dir="./tmp" || echo "failed $target"
       ;;
     "long-test")
-      ant testclasslist -Dtest.classlistprefix=long -Dtest.timeout=$(_timeout_for "test.long.timeout") -Dtest.classlistfile=<( _list_tests "long" ) || echo "failed $target"
+      ant testclasslist -Dtest.classlistprefix=long -Dtest.timeout=$(_timeout_for "test.long.timeout") -Dtest.classlistfile=<( _list_tests "long" ) -Dtmp.dir="./tmp" || echo "failed $target"
       ;;
     "jvm-dtest")
-      ant testclasslist -Dtest.classlistprefix=distributed -Dtest.timeout=$(_timeout_for "test.distributed.timeout") -Dtest.classlistfile=<( _list_distributed_tests_no_upgrade ) || echo "failed $target"
+      ant testclasslist -Dtest.classlistprefix=distributed -Dtest.timeout=$(_timeout_for "test.distributed.timeout") -Dtest.classlistfile=<( _list_distributed_tests_no_upgrade ) -Dtmp.dir="./tmp" || echo "failed $target"
       ;;
     *)
       echo "unregconised \"$target\""

--- a/jenkins-dsl/cassandra_job_dsl_seed.groovy
+++ b/jenkins-dsl/cassandra_job_dsl_seed.groovy
@@ -2,6 +2,9 @@
 //
 // Common Vars and Branch List
 //
+//  To update the variable via the Jenkins UI, use the EnvInject plugin
+//   example: https://github.com/apache/cassandra-builds/pull/19#issuecomment-610822772
+//
 ////////////////////////////////////////////////////////////
 
 def jobDescription = '<img src="http://cassandra.apache.org/img/cassandra_logo.png" /><br/>Apache Cassandra DSL-generated job - DSL git repo: <a href="https://gitbox.apache.org/repos/asf?p=cassandra-builds.git">cassandra-builds</a>'
@@ -129,8 +132,9 @@ job('Cassandra-template-artifacts') {
             task('.', '''
                 echo "Cleaning project…"; ant realclean;
                 echo "Pruning docker…" ; docker system prune -f --volumes ;
-                echo "Reporting disk usage…"; df -h ; du -hs `pwd` ; du -hs ../* ;
+                echo "Reporting disk usage…"; df -h ; find . -maxdepth 2 -type d -exec du -hs {} ';' ; du -hs ../* ;
                 echo "Cleaning tmp…";
+                find . -type d -name tmp -delete 2>/dev/null ;
                 find /tmp -type f -atime +3 -user jenkins -and -not -exec fuser -s {} ';' -and -delete 2>/dev/null
                 ''')
         }
@@ -189,8 +193,9 @@ job('Cassandra-template-test') {
                 echo "Finding job process orphans…"; if pgrep -af ${JOB_BASE_NAME}; then pkill -9 -f ${JOB_BASE_NAME}; fi;
                 echo "Cleaning project…"; ant realclean;
                 echo "Pruning docker…" ; docker system prune -f --volumes ;
-                echo "Reporting disk usage…"; df -h ; du -hs `pwd` ; du -hs ../* ;
+                echo "Reporting disk usage…"; df -h ; find . -maxdepth 2 -type d -exec du -hs {} ';' ; du -hs ../* ;
                 echo "Cleaning tmp…";
+                find . -type d -name tmp -delete 2>/dev/null ;
                 find /tmp -type f -atime +3 -user jenkins -and -not -exec fuser -s {} ';' -and -delete 2>/dev/null
             ''')
         }
@@ -249,8 +254,9 @@ job('Cassandra-template-dtest') {
                 echo "Finding job process orphans…"; if pgrep -af ${JOB_BASE_NAME}; then pkill -9 -f ${JOB_BASE_NAME}; fi;
                 echo "Cleaning project…"; ant realclean;
                 echo "Pruning docker…" ; docker system prune -f --volumes ;
-                echo "Reporting disk usage…"; df -h ; du -hs `pwd` ; du -hs ../* ;
+                echo "Reporting disk usage…"; df -h ; find . -maxdepth 2 -type d -exec du -hs {} ';' ; du -hs ../* ;
                 echo "Cleaning tmp…";
+                find . -type d -name tmp -delete 2>/dev/null ;
                 find /tmp -type f -atime +3 -user jenkins -and -not -exec fuser -s {} ';' -and -delete 2>/dev/null
             ''')
         }
@@ -314,8 +320,9 @@ matrixJob('Cassandra-template-cqlsh-tests') {
                 echo "Finding job process orphans…"; if pgrep -af ${JOB_BASE_NAME}; then pkill -9 -f ${JOB_BASE_NAME}; fi;
                 echo "Cleaning project…"; ant realclean;
                 echo "Pruning docker…" ; docker system prune -f --volumes ;
-                echo "Reporting disk usage…"; df -h ; du -hs `pwd` ; du -hs ../* ;
+                echo "Reporting disk usage…"; df -h ; find . -maxdepth 2 -type d -exec du -hs {} ';' ; du -hs ../* ;
                 echo "Cleaning tmp…";
+                find . -type d -name tmp -delete 2>/dev/null ;
                 find /tmp -type f -atime +3 -user jenkins -and -not -exec fuser -s {} ';' -and -delete 2>/dev/null
             ''')
         }
@@ -504,8 +511,9 @@ job('Cassandra-devbranch-artifacts') {
             task('.', '''
                 echo "Cleaning project…"; ant realclean;
                 echo "Pruning docker…" ; docker system prune -f --volumes ;
-                echo "Reporting disk usage…"; df -h ; du -hs `pwd` ; du -hs ../* ;
+                echo "Reporting disk usage…"; df -h ; find . -maxdepth 2 -type d -exec du -hs {} ';' ; du -hs ../* ;
                 echo "Cleaning tmp…";
+                find . -type d -name tmp -delete 2>/dev/null ;
                 find /tmp -type -f -atime +3 -user jenkins -and -not -exec fuser -s {} ';' -and -delete 2>/dev/null
                 ''')
         }
@@ -572,8 +580,9 @@ testTargets.each {
                     echo "Finding job process orphans…"; if pgrep -af ${JOB_BASE_NAME}; then pkill -9 -f ${JOB_BASE_NAME}; fi;
                     echo "Cleaning project…"; ant realclean;
                     echo "Pruning docker…" ; docker system prune -f --volumes ;
-                    echo "Reporting disk usage…"; df -h ; du -hs `pwd` ; du -hs ../* ;
+                    echo "Reporting disk usage…"; df -h ; find . -maxdepth 2 -type d -exec du -hs {} ';' ; du -hs ../* ;
                     echo "Cleaning tmp…";
+                    find . -type d -name tmp -delete 2>/dev/null ;
                     find /tmp -type f -atime +3 -user jenkins -and -not -exec fuser -s {} ';' -and -delete 2>/dev/null
                 ''')
             }
@@ -641,8 +650,9 @@ job('Cassandra-devbranch-dtest') {
                 echo "Finding job process orphans…"; if pgrep -af ${JOB_BASE_NAME}; then pkill -9 -f ${JOB_BASE_NAME}; fi;
                 echo "Cleaning project…"; ant realclean;
                 echo "Pruning docker…" ; docker system prune -f --volumes ;
-                echo "Reporting disk usage…"; df -h ; du -hs `pwd` ; du -hs ../* ;
+                echo "Reporting disk usage…"; df -h ; find . -maxdepth 2 -type d -exec du -hs {} ';' ; du -hs ../* ;
                 echo "Cleaning tmp…";
+                find . -type d -name tmp -delete 2>/dev/null ;
                 find /tmp -type f -atime +3 -user jenkins -and -not -exec fuser -s {} ';' -and -delete 2>/dev/null
             ''')
         }
@@ -714,8 +724,9 @@ matrixJob('Cassandra-devbranch-cqlsh-tests') {
                 echo "Finding job process orphans…"; if pgrep -af ${JOB_BASE_NAME}; then pkill -9 -f ${JOB_BASE_NAME}; fi;
                 echo "Cleaning project…"; ant realclean;
                 echo "Pruning docker…" ; docker system prune -f --volumes ;
-                echo "Reporting disk usage…"; df -h ; du -hs `pwd` ; du -hs ../* ;
+                echo "Reporting disk usage…"; df -h ; find . -maxdepth 2 -type d -exec du -hs {} ';' ; du -hs ../* ;
                 echo "Cleaning tmp…";
+                find . -type d -name tmp -delete 2>/dev/null ;
                 find /tmp -type f -atime +3 -user jenkins -and -not -exec fuser -s {} ';' -and -delete 2>/dev/null
             ''')
         }


### PR DESCRIPTION
From the dtest build scripts remove the "--no-site-packages" flag (which breaks virtualenv >20), and add a tmpdir environment variable (pointing to a `tmp` folder in current directory)