### PR TITLE
Fail devbranch on stress-test and fqltool-test compilation failures

### DIFF
--- a/build-scripts/cassandra-test.sh
+++ b/build-scripts/cassandra-test.sh
@@ -64,7 +64,14 @@ _main() {
   ant clean jar
 
   case $target in
-    "stress-test" | "fqltool-test")
+    "stress-test")
+      # hard fail on test compilation, put dont fail the test run as unstable test reports are processed
+      ant stress-build-test
+      ant $target -Dtmp.dir="$(pwd)/tmp" || echo "failed $target"
+      ;;
+    "fqltool-test")
+      # hard fail on test compilation, put dont fail the test run so unstable test reports are processed
+      ant fqltool-build-test
       ant $target -Dtmp.dir="$(pwd)/tmp" || echo "failed $target"
       ;;
     "test")


### PR DESCRIPTION
We don't fail on the `ant test* …` process because we want the "unstable" result and the test results still to be processed.
 (Normally we fail the test run instead on the lack of test reports. Except the devbranch because there not every branch (or jdk11) can run on each test type and so a skipped run is ok with empty test results.
Quick fix is the preceding `ant fqltool-build-test` call that we can hard fail on.