### PR TITLE
Don't build cython extensions for cassandra-driver in testing images

### DIFF
--- a/docker/testing/ubuntu2004_j11.docker
+++ b/docker/testing/ubuntu2004_j11.docker
@@ -95,17 +95,23 @@ ENV ANT_HOME=/usr/share/ant
 
 # run pip commands and setup virtualenv (note we do this after we switch to cassandra user so we
 # setup the virtualenv for the cassandra user and not the root user by accident) for Python 3.6/3.7/3.8
+# Don't build cython extensions when installing cassandra-driver. During test execution the driver
+# dependency is refreshed via pip install --upgrade, so that driver changes can be pulled in without
+# requiring the image to be rebuilt. Rebuilding compiled extensions is costly and is disabled by
+# default in test jobs using the CASS_DRIVER_X env vars below. However, if the extensions are
+# included in the base image, the compiled objects are not updated by pip at run time, which can
+# cause errors if the tests rely on new driver functionality or bug fixes.
 RUN virtualenv --python=python3.6 env3.6
 RUN chmod +x env3.6/bin/activate
-RUN /bin/bash -c "source ~/env3.6/bin/activate && pip3 install --upgrade pip && pip3 install Cython && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
+RUN /bin/bash -c "export CASS_DRIVER_NO_CYTHON=1 CASS_DRIVER_NO_EXTENSIONS=1 && source ~/env3.6/bin/activate && pip3 install --upgrade pip && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
 
 RUN virtualenv --python=python3.7 env3.7
 RUN chmod +x env3.7/bin/activate
-RUN /bin/bash -c "source ~/env3.7/bin/activate && pip3 install --upgrade pip && pip3 install Cython && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
+RUN /bin/bash -c "export CASS_DRIVER_NO_CYTHON=1 CASS_DRIVER_NO_EXTENSIONS=1 && source ~/env3.7/bin/activate && pip3 install --upgrade pip && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
 
 RUN virtualenv --python=python3.8 env3.8
 RUN chmod +x env3.8/bin/activate
-RUN /bin/bash -c "source ~/env3.8/bin/activate && pip3 install --upgrade pip && pip3 install Cython && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
+RUN /bin/bash -c "export CASS_DRIVER_NO_CYTHON=1 CASS_DRIVER_NO_EXTENSIONS=1 && source ~/env3.8/bin/activate && pip3 install --upgrade pip && pip3 install -r /opt/requirements.txt && pip3 freeze --user"
 
 # we need to make SSH less strict to prevent various dtests from failing when they attempt to
 # git clone a given commit/tag/etc


### PR DESCRIPTION
The cython extensions to the driver create `.so` files, which don't get updated when the tests run, even though the latest `.py` files get pulled from the driver repo via `pip`. This is a problem when tests depend on new functionality or bug fixes in the driver as the `.so` files tend to go out of sync. Not installing the extensions might have an impact on the test runtime that we need to assess but AFAICT the only alternative is to force the extensions to be rebuilt for every test run, which is going to add a lot more to the runtime.