### PR TITLE
In Jenkins devbranch pipeline, summarise the SHAs (when consistent) rather than printing them all out

### DIFF
--- a/jenkins-dsl/cassandra_pipeline.groovy
+++ b/jenkins-dsl/cassandra_pipeline.groovy
@@ -316,7 +316,7 @@ pipeline {
             }
             slackSend channel: '#cassandra-builds-patches', message: ":apache: <${env.BUILD_URL}|${currentBuild.fullDisplayName}> completed: ${currentBuild.result}. <https://github.com/${REPO}/cassandra/commit/${commit_head_sha}|${REPO} ${commit_head_sha}>\n${commit_head_msg}"
             sh "echo \"cassandra-builds at: `git -C cassandra-builds log -1 --pretty=format:'%h %an %ad %s'`\" > builds.head"
-            sh "find . -type f -name \\*.head -exec cat {} \\;"
+            sh "./cassandra-builds/jenkins-dsl/print-shas.sh"
             sh "xz TESTS-TestSuites.xml"
             sh "echo \"For test report and logs see https://nightlies.apache.org/cassandra/devbranch/${JOB_NAME}/${BUILD_NUMBER}/\""
         }

--- a/jenkins-dsl/print-shas.sh
+++ b/jenkins-dsl/print-shas.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Print the SHAs used in all the stage jobs.
+# If they all match then print just them, else print every job's used SHA
+#
+
+if [ $(grep ") cassandra" *.head | sort -k4 | uniq -f3 | sed -n '$=') -eq 3 ]; then
+  echo "The folllowing SHAs were consistently used in all jobs in the pipeline…"
+  grep ") cassandra" *.head | awk '{$1=$2=$3=""; print $0}' | sort -u
+else
+  echo "Different SHAs were used in different jobs in the pipeline. Printing everything…"
+  grep ") cassandra" *.head
+fi


### PR DESCRIPTION

Coming back around to cleaning up the mess of printing out all the SHAs used in all the jobs and splits in a pipeline.
ref: https://issues.apache.org/jira/browse/CASSANDRA-16128

This patch, detects when they all are consistent, and in that case prints just a summary.

@bereng 