### PR TITLE
Fixes to test failures introduced by docker `--cpus` limits

### DIFF
--- a/build-scripts/cassandra-dtest-pytest-docker.sh
+++ b/build-scripts/cassandra-dtest-pytest-docker.sh
@@ -16,10 +16,10 @@ if [ "$#" -lt 3 ]; then
     export PYTHONIOENCODING=utf-8
     export PYTHONUNBUFFERED=true
     echo "running: git clone --depth 1 --single-branch --branch=$BRANCH https://github.com/$REPO/cassandra.git"
-    git clone --depth 1 --single-branch --branch=$BRANCH https://github.com/$REPO/cassandra.git
+    git clone --quiet --depth 1 --single-branch --branch=$BRANCH https://github.com/$REPO/cassandra.git
     cd cassandra
     echo "running: git clone --depth 1 --single-branch --branch=$DTEST_BRANCH $DTEST_REPO"
-    git clone --depth 1 --single-branch --branch=$DTEST_BRANCH $DTEST_REPO
+    git clone --quiet --depth 1 --single-branch --branch=$DTEST_BRANCH $DTEST_REPO
     echo "cassandra-dtest-pytest.sh (${1} ${2}) cassandra: `git log -1 --pretty=format:'%h %an %ad %s'`" | tee "${1}-$(echo $2 | sed 's/\//-/')-cassandra.head"
     echo "cassandra-dtest-pytest.sh (${1} ${2}) cassandra-dtest: `git -C cassandra-dtest log -1 --pretty=format:'%h %an %ad %s'`" | tee -a "${1}-$(echo $2 | sed 's/\//-/')-cassandra.head"
     echo "cassandra-dtest-pytest.sh (${1} ${2}) cassandra-builds: `git -C ../cassandra-builds log -1 --pretty=format:'%h %an %ad %s'`" | tee -a "${1}-$(echo $2 | sed 's/\//-/')-cassandra.head"
@@ -43,6 +43,7 @@ DTEST_REPO=$3
 DTEST_BRANCH=$4
 EOF
 
+    set -x # debug, sometimes ${docker_cpus} is not evaluated
     # Jenkins agents run multiple executors per machine. `jenkins_executors=1` is used for anything non-jenkins.
     jenkins_executors=1
     if [[ ! -z ${JENKINS_URL+x} ]] && [[ ! -z ${NODE_NAME+x} ]] ; then
@@ -57,7 +58,7 @@ EOF
     [[ "$(docker images -q $DOCKER_IMAGE 2>/dev/null)" != "" ]] || docker pull -q $DOCKER_IMAGE
 
     echo "cassandra-dtest-pytest-docker.sh: running: git clone --single-branch --depth 1 --branch $BUILDSBRANCH $BUILDSREPO; sh ./cassandra-builds/build-scripts/cassandra-dtest-pytest-docker.sh $TARGET $SPLIT_CHUNK"
-    ID=$(docker run --cpus=${docker_cpus} -m 15g --memory-swap 15g --env-file env.list -dt $DOCKER_IMAGE dumb-init bash -ilc "git clone --single-branch --depth 1 --branch $BUILDSBRANCH $BUILDSREPO; sh ./cassandra-builds/build-scripts/cassandra-dtest-pytest-docker.sh $TARGET $SPLIT_CHUNK")
+    ID=$(docker run --cpus=${docker_cpus} -m 15g --memory-swap 15g --env-file env.list -dt $DOCKER_IMAGE dumb-init bash -ilc "git clone --quiet --single-branch --depth 1 --branch $BUILDSBRANCH $BUILDSREPO; sh ./cassandra-builds/build-scripts/cassandra-dtest-pytest-docker.sh $TARGET $SPLIT_CHUNK")
 
     # use docker attach instead of docker wait to get output
     docker attach --no-stdin $ID

--- a/jenkins-dsl/cassandra_job_dsl_seed.groovy
+++ b/jenkins-dsl/cassandra_job_dsl_seed.groovy
@@ -74,7 +74,7 @@ if(binding.hasVariable("CASSANDRA_DTEST_TEST_TARGETS")) {
 def dtestDockerImage = 'apache/cassandra-testing-ubuntu2004-java11'
 
 // expected longest job runtime
-def maxJobHours = 18
+def maxJobHours = 12
 if(binding.hasVariable("MAX_JOB_HOURS")) {
     maxJobHours = ${MAX_JOB_HOURS}
 }
@@ -189,7 +189,7 @@ matrixJob('Cassandra-template-test') {
     }
     wrappers {
         timeout {
-            noActivity(1200)
+            noActivity(5400)
         }
         timestamps()
     }
@@ -251,7 +251,7 @@ matrixJob('Cassandra-template-dtest-matrix') {
     }
     wrappers {
         timeout {
-            noActivity(1200)
+            noActivity(5400)
         }
         timestamps()
     }
@@ -839,7 +839,7 @@ testTargets.each {
         }
         wrappers {
             timeout {
-                noActivity(1200)
+                noActivity(5400)
             }
             timestamps()
         }
@@ -947,7 +947,7 @@ archs.each {
             }
             wrappers {
                 timeout {
-                    noActivity(2400)
+                    noActivity(5400)
                 }
                 timestamps()
             }


### PR DESCRIPTION
 - don't apply cpu limits to long-test (the View* tests fail)
 - don't inner split long-test, along with the burn tests give them extra resource allocation
 - debug docker_cpus evaluation (crashing on ci-caassandra, not yet reproduced)
 - make git cloning quiet
 - increase build timeouts from 20 to 90 minutes (limited cpus can slow down the queue throughput)
 - decrease docker prune time period, as no jobs run for more than 12 hours anymore