### PR TITLE
Only accept valid number values for `jenkins_executor`

### DIFF
--- a/build-scripts/cassandra-dtest-pytest-docker.sh
+++ b/build-scripts/cassandra-dtest-pytest-docker.sh
@@ -47,7 +47,9 @@ EOF
     # Jenkins agents run multiple executors per machine. `jenkins_executors=1` is used for anything non-jenkins.
     jenkins_executors=1
     if [[ ! -z ${JENKINS_URL+x} ]] && [[ ! -z ${NODE_NAME+x} ]] ; then
-        jenkins_executors=$(curl -s --retry 9 --retry-connrefused --retry-delay 1 "${JENKINS_URL}/computer/${NODE_NAME}/api/json?pretty=true" | grep 'numExecutors' | awk -F' : ' '{print $2}' | cut -d',' -f1)
+        fetched_jenkins_executors=$(curl -s --retry 9 --retry-connrefused --retry-delay 1 "${JENKINS_URL}/computer/${NODE_NAME}/api/json?pretty=true" | grep 'numExecutors' | awk -F' : ' '{print $2}' | cut -d',' -f1)
+        # use it if we got a valid number (despite retry settings the curl above can still fail)
+        [[ ${fetched_jenkins_executors} =~ '^[0-9]+$' ]] && jenkins_executors=${fetched_jenkins_executors}
     fi
     cores=1
     command -v nproc >/dev/null 2>&1 && cores=$(nproc --all)

--- a/build-scripts/cassandra-test-docker.sh
+++ b/build-scripts/cassandra-test-docker.sh
@@ -67,7 +67,9 @@ EOF
     # Jenkins agents run multiple executors per machine. `jenkins_executors=1` is used for anything non-jenkins.
     jenkins_executors=1
     if [[ ! -z ${JENKINS_URL+x} ]] && [[ ! -z ${NODE_NAME+x} ]] ; then
-        jenkins_executors=$(curl -s --retry 9 --retry-connrefused --retry-delay 1 "${JENKINS_URL}/computer/${NODE_NAME}/api/json?pretty=true" | grep 'numExecutors' | awk -F' : ' '{print $2}' | cut -d',' -f1)
+        fetched_jenkins_executors=$(curl -s --retry 9 --retry-connrefused --retry-delay 1 "${JENKINS_URL}/computer/${NODE_NAME}/api/json?pretty=true" | grep 'numExecutors' | awk -F' : ' '{print $2}' | cut -d',' -f1)
+        # use it if we got a valid number (despite retry settings the curl above can still fail
+        [[ ${fetched_jenkins_executors} =~ '^[0-9]+$' ]] && jenkins_executors=${fetched_jenkins_executors}
     fi
     cores=1
     command -v nproc >/dev/null 2>&1 && cores=$(nproc --all)
@@ -125,7 +127,6 @@ EOF
         docker attach --no-stdin $docker_id > build/test/logs/docker_attach_${i}.log &
         PROCESS_IDS+=( $! )
         DOCKER_IDS+=( $docker_id )
-break
     done
 
     exit_result=0


### PR DESCRIPTION
despite retry settings the curl above can still fail

@bereng 