### PR TITLE
Migrate from bintray uploads to ASF's jfrog artifactory. 

### DIFF
--- a/cassandra-release/prepare_release.sh
+++ b/cassandra-release/prepare_release.sh
@@ -208,7 +208,7 @@ then
     execute "ant realclean"
     execute "ant publish -Drelease=true -Dbase.version=$release"
 
-    echo "Artifacts uploaded, please close release on repository.apache.org and indicate the staging number:" 1>&3 2>&4
+    echo "Artifacts uploaded, find the staging repository on repository.apache.org, \"Close\" it, and indicate its staging number:" 1>&3 2>&4
     read -p "staging number? " staging_number 1>&3 2>&4
 
     execute "cd $tmp_dir"


### PR DESCRIPTION
Also uploading deb and rpm packages to separate artifactory groups.
And a small fix to instructions printed out (we don't 'release' staging repositories until after the vote :( 

This was used for the 4.0-rc1 release, and will (has to be) used for all subsequent releases (post-vote steps).