### PR TITLE
Updated ant to 1.10.12 for Docker images

### DIFF
--- a/docker/almalinux-image.docker
+++ b/docker/almalinux-image.docker
@@ -11,7 +11,6 @@ VOLUME ${RPM_DIST_DIR}
 
 # install deps
 RUN yum -y install \
-   ant \
    git \
    java-1.8.0-openjdk-devel \
    java-11-openjdk-devel \
@@ -20,16 +19,20 @@ RUN yum -y install \
    sudo \
    python3-pip
 
-RUN until curl -S -s --retry 9 --retry-connrefused --retry-delay 1 http://mirror.centos.org/centos/7/os/x86_64/Packages/ant-junit-1.9.4-2.el7.noarch.rpm -o ant-junit-1.9.4-2.el7.noarch.rpm ; do echo "curl failed… trying again… " ; done
-
-RUN rpm -i --nodeps ant-junit-1.9.4-2.el7.noarch.rpm
-
 RUN pip3 install --upgrade pip
 
 # install Sphinx to generate docs
 RUN pip3 install \
    Sphinx \
    sphinx_rtd_theme
+
+# install ant
+RUN mkdir /usr/share/ant && \
+    wget --tries 9 https://dlcdn.apache.org/ant/binaries/apache-ant-1.10.12-bin.tar.gz && \
+    tar --strip-components 1 -xf apache-ant-1.10.12-bin.tar.gz -C /usr/share/ant && \
+    rm -f apache-ant-1.10.12-bin.tar.gz
+ENV ANT_HOME=/usr/share/ant
+ENV PATH="${ANT_HOME}/bin:${PATH}"
 
 # create and change to build user
 RUN adduser build
@@ -40,7 +43,7 @@ USER build
 
 RUN mkdir -p $RPM_BUILD_DIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
-# Clone Cassandra and cache maven artifacts
+# clone Cassandra and cache maven artifacts
 ARG CASSANDRA_GIT_URL=https://github.com/apache/cassandra.git
 RUN git clone ${CASSANDRA_GIT_URL} ${CASSANDRA_DIR}
 WORKDIR $CASSANDRA_DIR

--- a/docker/buster-image.docker
+++ b/docker/buster-image.docker
@@ -13,7 +13,6 @@ RUN echo 'APT::Acquire::Retries "9";' > /etc/apt/apt.conf.d/80-retries
 
 # install deps
 RUN apt-get update && apt-get -y install \
-   ant \
    build-essential \
    curl \
    devscripts \
@@ -28,6 +27,14 @@ RUN echo 'deb http://ftp.debian.org/debian stretch main' >> /etc/apt/sources.lis
     && sed -i '$d' /etc/apt/sources.list \
     && apt-get update \
     && update-java-alternatives --set java-1.8.0-openjdk-$(dpkg --print-architecture)
+
+# install ant
+RUN mkdir /usr/share/ant && \
+    wget --tries 9 https://dlcdn.apache.org/ant/binaries/apache-ant-1.10.12-bin.tar.gz && \
+    tar --strip-components 1 -xf apache-ant-1.10.12-bin.tar.gz -C /usr/share/ant && \
+    rm -f apache-ant-1.10.12-bin.tar.gz
+ENV ANT_HOME=/usr/share/ant
+ENV PATH="${ANT_HOME}/bin:${PATH}"
 
 # create and change to build user
 RUN adduser --disabled-login --gecos build build && gpasswd -a build sudo

--- a/docker/centos8-image.docker
+++ b/docker/centos8-image.docker
@@ -11,7 +11,6 @@ VOLUME ${RPM_DIST_DIR}
 
 # install deps
 RUN yum -y install \
-   ant \
    git \
    java-1.8.0-openjdk-devel \
    java-11-openjdk-devel \
@@ -20,16 +19,20 @@ RUN yum -y install \
    sudo \
    python3-pip
 
-RUN until curl -S -s --retry 9 --retry-connrefused --retry-delay 1 http://mirror.centos.org/centos/7/os/x86_64/Packages/ant-junit-1.9.4-2.el7.noarch.rpm -o ant-junit-1.9.4-2.el7.noarch.rpm ; do echo "curl failed… trying again… " ; done
-
-RUN rpm -i --nodeps ant-junit-1.9.4-2.el7.noarch.rpm
-
 RUN pip3 install --upgrade pip
 
 # install Sphinx to generate docs
 RUN pip3 install \
    Sphinx \
    sphinx_rtd_theme
+
+# install ant
+RUN mkdir /usr/share/ant && \
+    wget --tries 9 https://dlcdn.apache.org/ant/binaries/apache-ant-1.10.12-bin.tar.gz && \
+    tar --strip-components 1 -xf apache-ant-1.10.12-bin.tar.gz -C /usr/share/ant && \
+    rm -f apache-ant-1.10.12-bin.tar.gz
+ENV ANT_HOME=/usr/share/ant
+ENV PATH="${ANT_HOME}/bin:${PATH}"
 
 # create and change to build user
 RUN adduser build
@@ -40,7 +43,7 @@ USER build
 
 RUN mkdir -p $RPM_BUILD_DIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
-# Clone Cassandra and cache maven artifacts
+# clone Cassandra and cache maven artifacts
 ARG CASSANDRA_GIT_URL=https://github.com/apache/cassandra.git
 RUN git clone ${CASSANDRA_GIT_URL} ${CASSANDRA_DIR}
 WORKDIR $CASSANDRA_DIR

--- a/docker/jessie-image.docker
+++ b/docker/jessie-image.docker
@@ -16,7 +16,6 @@ RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-bac
 
 # install deps
 RUN apt-get update -o Acquire::Check-Valid-Until=false && apt-get -y install \
-   ant \
    build-essential \
    curl \
    devscripts \
@@ -32,6 +31,14 @@ RUN apt-get -y -t jessie-backports install \
    python-sphinx-rtd-theme
 
 RUN update-java-alternatives --set java-1.8.0-openjdk-$(dpkg --print-architecture)
+
+# install ant
+RUN mkdir /usr/share/ant && \
+    wget --tries 9 https://dlcdn.apache.org/ant/binaries/apache-ant-1.10.12-bin.tar.gz && \
+    tar --strip-components 1 -xf apache-ant-1.10.12-bin.tar.gz -C /usr/share/ant && \
+    rm -f apache-ant-1.10.12-bin.tar.gz
+ENV ANT_HOME=/usr/share/ant
+ENV PATH="${ANT_HOME}/bin:${PATH}"
 
 # create and change to build user
 RUN adduser --disabled-login --gecos build build && gpasswd -a build sudo

--- a/docker/testing/ubuntu1910_j11.docker
+++ b/docker/testing/ubuntu1910_j11.docker
@@ -66,10 +66,16 @@ RUN chmod 0644 /opt/requirements.txt
 RUN pip3 install virtualenv
 RUN pip3 install --upgrade wheel
 
-# openjdk + ant
+# openjdk
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-11-jdk ant ant-optional
+    apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-11-jdk
+
+# ant
+RUN mkdir /usr/share/ant && \
+    wget --tries 9 https://dlcdn.apache.org/ant/binaries/apache-ant-1.10.12-bin.tar.gz && \
+    tar --strip-components 1 -xf apache-ant-1.10.12-bin.tar.gz -C /usr/share/ant && \
+    rm -f apache-ant-1.10.12-bin.tar.gz
 
 # make Java 8 the default executable (we use to run all tests against Java 8)
 RUN update-java-alternatives --set java-1.8.0-openjdk-$(dpkg --print-architecture)
@@ -92,11 +98,13 @@ WORKDIR /home/cassandra
 
 # Add environment variables for Ant and Java and add them to the PATH
 RUN echo 'export ANT_HOME=/usr/share/ant' >> /home/cassandra/.bashrc && \
+    echo 'export PATH=${ANT_HOME}/bin:${PATH}' >> /home/cassandra/.bashrc && \
     echo 'export JAVA8_HOME=/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)' >> /home/cassandra/.bashrc && \
     echo 'export JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-$(dpkg --print-architecture)' >> /home/cassandra/.bashrc && \
     echo 'export JAVA_HOME=$JAVA8_HOME' >> /home/cassandra/.bashrc
 
 ENV ANT_HOME=/usr/share/ant
+ENV PATH="${ANT_HOME}/bin:${PATH}"
 
 # run pip commands and setup virtualenv (note we do this after we switch to cassandra user so we
 # setup the virtualenv for the cassandra user and not the root user by accident) for Python 3.6/3.7/3.8

--- a/docker/testing/ubuntu2004_j11.docker
+++ b/docker/testing/ubuntu2004_j11.docker
@@ -74,10 +74,16 @@ RUN pip2 install --upgrade wheel
 RUN pip3 install virtualenv
 RUN pip3 install --upgrade wheel
 
-# openjdk + ant
+# openjdk
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-11-jdk ant ant-optional
+    apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-11-jdk
+
+# ant
+RUN mkdir /usr/share/ant && \
+    wget --tries 9 https://dlcdn.apache.org/ant/binaries/apache-ant-1.10.12-bin.tar.gz && \
+    tar --strip-components 1 -xf apache-ant-1.10.12-bin.tar.gz -C /usr/share/ant && \
+    rm -f apache-ant-1.10.12-bin.tar.gz
 
 # make Java 8 the default executable (we use to run all tests against Java 8)
 RUN update-java-alternatives --set java-1.8.0-openjdk-$(dpkg --print-architecture)
@@ -104,11 +110,13 @@ WORKDIR /home/cassandra
 
 # Add environment variables for Ant and Java and add them to the PATH
 RUN echo 'export ANT_HOME=/usr/share/ant' >> /home/cassandra/.bashrc && \
+    echo 'export PATH=${ANT_HOME}/bin:${PATH}' >> /home/cassandra/.bashrc && \
     echo 'export JAVA8_HOME=/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)' >> /home/cassandra/.bashrc && \
     echo 'export JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-$(dpkg --print-architecture)' >> /home/cassandra/.bashrc && \
     echo 'export JAVA_HOME=$JAVA8_HOME' >> /home/cassandra/.bashrc
 
 ENV ANT_HOME=/usr/share/ant
+ENV PATH="${ANT_HOME}/bin:${PATH}"
 
 # run pip commands and setup virtualenv (note we do this after we switch to cassandra user so we
 # setup the virtualenv for the cassandra user and not the root user by accident) for Python 3.6/3.7/3.8


### PR DESCRIPTION
It is required for CASSANDRA-16630. I've tested locally only Ubuntu testing images. If you see no issues with the current approach, I'll get tested the rest.