### PR TITLE
Revert "Updated ant to 1.10.12 for cassandra-artifacts build"

### DIFF
--- a/jenkins-dsl/cassandra_job_dsl_seed.groovy
+++ b/jenkins-dsl/cassandra_job_dsl_seed.groovy
@@ -392,15 +392,11 @@ cassandraBranches.each {
             node / scm / branches / 'hudson.plugins.git.BranchSpec' / name(branchName)
         }
         steps {
-            // cassandra-artifacts.sh script is the only place where ant is called directly. In all other places ant is
-            // called inside a docker container, so there is no need to specify version in the pipeline script.
-            withAnt (installation: 'ant_1.10.12') {
-                shell("""
-                        ./cassandra-builds/build-scripts/cassandra-artifacts.sh ;
-                        wget --retry-connrefused --waitretry=1 "\${BUILD_URL}/timestamps/?time=HH:mm:ss&timeZone=UTC&appendLog" -qO - > console.log || echo wget failed ;
-                        xz console.log
-                        """)
-            }
+            shell("""
+                    ./cassandra-builds/build-scripts/cassandra-artifacts.sh ;
+                    wget --retry-connrefused --waitretry=1 "\${BUILD_URL}/timestamps/?time=HH:mm:ss&timeZone=UTC&appendLog" -qO - > console.log || echo wget failed ;
+                    xz console.log
+                  """)
         }
         publishers {
             publishOverSsh {
@@ -832,18 +828,14 @@ matrixJob('Cassandra-devbranch-artifacts') {
     }
     steps {
         buildDescription('', buildDescStr)
-        // cassandra-artifacts.sh script is the only place where ant is called directly. In all other places ant is
-        // called inside a docker container, so there is no need to specify version in the pipeline script.
-        withAnt (installation: 'ant_1.10.12') {
-            shell("""
-                    git clean -xdff ;
-                    git clone --depth 1 --single-branch -b ${buildsBranch} ${buildsRepo} ;
-                    echo "cassandra-builds at: `git -C cassandra-builds log -1 --pretty=format:'%h %an %ad %s'`" ;
-                    ./cassandra-builds/build-scripts/cassandra-artifacts.sh ;
-                    wget --retry-connrefused --waitretry=1 "\${BUILD_URL}/timestamps/?time=HH:mm:ss&timeZone=UTC&appendLog" -qO - > console.log || echo wget failed ;
-                    xz console.log
-                    """)
-        }
+        shell("""
+                git clean -xdff ;
+                git clone --depth 1 --single-branch -b ${buildsBranch} ${buildsRepo} ;
+                echo "cassandra-builds at: `git -C cassandra-builds log -1 --pretty=format:'%h %an %ad %s'`" ;
+                ./cassandra-builds/build-scripts/cassandra-artifacts.sh ;
+                wget --retry-connrefused --waitretry=1 "\${BUILD_URL}/timestamps/?time=HH:mm:ss&timeZone=UTC&appendLog" -qO - > console.log || echo wget failed ;
+                xz console.log
+                """)
     }
     publishers {
         publishOverSsh {


### PR DESCRIPTION
Reverts apache/cassandra-builds#63

https://ci-cassandra.apache.org/view/misc/job/Cassandra-Job-DSL/255/console
```
ERROR: (cassandra_job_dsl_seed.groovy, line 397) No signature of method: javaposse.jobdsl.dsl.helpers.step.StepContext.withAnt() is applicable for argument types: (java.util.LinkedHashMap, cassandra_job_dsl_seed$_run_closure6$_closure68$_closure75$_closure77) values: [[installation:ant_1.10.12], cassandra_job_dsl_seed$_run_closure6$_closure68$_closure75$_closure77@76665f2a]
Possible solutions: wait(), ant(), nant(), with(groovy.lang.Closure)
```
