### PR TITLE
Use the git clone reference feature in jenkins, pointing each split's git clone to the first split

### DIFF
--- a/jenkins-dsl/cassandra_job_dsl_seed.groovy
+++ b/jenkins-dsl/cassandra_job_dsl_seed.groovy
@@ -272,7 +272,7 @@ matrixJob('Cassandra-template-dtest-matrix') {
                 cleanAfterCheckout()
                 cloneOption {
                     shallow(false)
-                    reference('.')
+                    reference('../1')
                     honorRefspec(true)
                     noTags(true)
                     timeout(maxJobHours * 60)
@@ -541,6 +541,7 @@ cassandraBranches.each {
                           }
                         }
                     }
+                    cleanWs()
                 }
             }
         }
@@ -643,6 +644,7 @@ cassandraBranches.each {
                             }
                           }
                         }
+                        cleanWs()
                     }
                 }
             }
@@ -716,6 +718,7 @@ cassandraBranches.each {
                     }
                   }
                 }
+                cleanWs()
             }
         }
     }


### PR DESCRIPTION
… 

Also clean the workspace when the job is done.