### PR TITLE
Replace the deprecated postBuildScript with matrixPostBuildScript (in 'BOTH' mode)

### DIFF
--- a/jenkins-dsl/cassandra_job_dsl_seed.groovy
+++ b/jenkins-dsl/cassandra_job_dsl_seed.groovy
@@ -409,10 +409,11 @@ cassandraBranches.each {
                 }
                 failOnError(false)
             }
-            postBuildScript {
+            matrixPostBuildScript {
               buildSteps {
                 markBuildUnstable(false)
                 postBuildStep {
+                    executeOn('BOTH')
                     stopOnFailure(false)
                     results(['SUCCESS','UNSTABLE','FAILURE','NOT_BUILT','ABORTED'])
                     buildSteps {
@@ -514,10 +515,11 @@ cassandraBranches.each {
                         }
                         failOnError(false)
                     }
-                    postBuildScript {
+                    matrixPostBuildScript {
                         buildSteps {
                           markBuildUnstable(false)
                           postBuildStep {
+                              executeOn('BOTH')
                               stopOnFailure(false)
                               results(['SUCCESS','UNSTABLE','FAILURE','NOT_BUILT','ABORTED'])
                               buildSteps {
@@ -617,10 +619,11 @@ cassandraBranches.each {
                                 publishTestStabilityData()
                             }
                         }
-                        postBuildScript {
+                        matrixPostBuildScript {
                           buildSteps {
                             markBuildUnstable(false)
                             postBuildStep {
+                                executeOn('BOTH')
                                 stopOnFailure(false)
                                 results(['SUCCESS','UNSTABLE','FAILURE','NOT_BUILT','ABORTED'])
                                 buildSteps {
@@ -691,10 +694,11 @@ cassandraBranches.each {
                         xz console.log
                         """)
                 }
-                postBuildScript {
+                matrixPostBuildScript {
                   buildSteps {
                     markBuildUnstable(false)
                     postBuildStep {
+                        executeOn('BOTH')
                         stopOnFailure(false)
                         results(['SUCCESS','UNSTABLE','FAILURE','NOT_BUILT','ABORTED'])
                         buildSteps {
@@ -857,11 +861,12 @@ matrixJob('Cassandra-devbranch-artifacts') {
             }
             failOnError(false)
         }
-        postBuildScript {
+        matrixPostBuildScript {
           buildSteps {
             markBuildUnstable(false)
             postBuildStep {
                 stopOnFailure(false)
+                executeOn('BOTH')
                 results(['SUCCESS','UNSTABLE','FAILURE','NOT_BUILT','ABORTED'])
                 buildSteps {
                   shell {
@@ -987,10 +992,11 @@ testTargets.each {
             archiveJunit('build/test/**/TEST-*.xml') {
                 allowEmptyResults()
             }
-            postBuildScript {
+            matrixPostBuildScript {
               buildSteps {
                 markBuildUnstable(false)
                 postBuildStep {
+                    executeOn('BOTH')
                     stopOnFailure(false)
                     results(['SUCCESS','UNSTABLE','FAILURE','NOT_BUILT','ABORTED'])
                     buildSteps {
@@ -1132,10 +1138,11 @@ archs.each {
                     fingerprint()
                 }
                 archiveJunit('nosetests.xml')
-                postBuildScript {
+                matrixPostBuildScript {
                   buildSteps {
                     markBuildUnstable(false)
                     postBuildStep {
+                        executeOn('BOTH')
                         stopOnFailure(false)
                         results(['SUCCESS','UNSTABLE','FAILURE','NOT_BUILT','ABORTED'])
                         buildSteps {
@@ -1254,10 +1261,11 @@ matrixJob('Cassandra-devbranch-cqlsh-tests') {
             fingerprint()
         }
         archiveJunit('**/cqlshlib.xml')
-        postBuildScript {
+        matrixPostBuildScript {
           buildSteps {
             markBuildUnstable(false)
             postBuildStep {
+                executeOn('BOTH')
                 stopOnFailure(false)
                 results(['SUCCESS','UNSTABLE','FAILURE','NOT_BUILT','ABORTED'])
                 buildSteps {


### PR DESCRIPTION
Expected to remove the warnings (which are flooding the console outputs)
```
23:16:31 [PostBuildScript] - [WARN] This multi-configuration project post-build action was migrated from a plugin version prior to 1.0.0 as an 'Execute scripts' post-build action, because is not possible to automatically migrate a post-build action to another kind of post-build action. To remove the mandatory dependency between post-build script plugin and the matrix plugin, there is an extra post-build action called 'Execute Scripts on Matrix'. Please add all post-build scripts of this matrix project separately as a post-build action 'Execute Scripts on Matrix' and remove all 'Execute Scripts' entries.
```