### PR TITLE
add slowest 100 tests to pytest output

### DIFF
--- a/build-scripts/cassandra-dtest-pytest.sh
+++ b/build-scripts/cassandra-dtest-pytest.sh
@@ -100,7 +100,7 @@ if [ "x${DTEST_SPLIT_CHUNK}" != "x" ] ; then
     SPLIT_TESTS=$(split -n r/${DTEST_SPLIT_CHUNK} ${WORKSPACE}/test_list.txt)
 fi
 
-PYTEST_OPTS="-vv --log-cli-level=DEBUG --junit-xml=nosetests.xml --junit-prefix=${DTEST_TARGET} -s"
+PYTEST_OPTS="-vv --durations=100 --log-cli-level=DEBUG --junit-xml=nosetests.xml --junit-prefix=${DTEST_TARGET} -s"
 
 pytest ${PYTEST_OPTS} --cassandra-dir=$CASSANDRA_DIR ${DTEST_ARGS} ${SPLIT_TESTS} 2>&1 | tee -a ${WORKSPACE}/test_stdout.txt
 


### PR DESCRIPTION
On each run, we can trivially add the slowest 100 runs to the test output to give us something to target with potential optimization, comparison to in-jvm dtest, or deprecation.

100 is... very arbitrary. 10 might be fine. Or 50. Or 0 so it prints all! No real opinion there.

In a similar vein to the JIRA on unit test runtimes being lopsided and hot-spotty: https://issues.apache.org/jira/browse/CASSANDRA-17371