### PR TITLE
CASSANDRA-18017 Use the no-build-test flag in Jenkins to skip unnecessary checks

### DIFF
--- a/build-scripts/cassandra-test.sh
+++ b/build-scripts/cassandra-test.sh
@@ -67,7 +67,7 @@ _run_testlist() {
       testlist="$( _list_tests "${_target_prefix}" | head -n1)"
     fi
     ant clean jar
-    ant $_testlist_target -Dtest.classlistprefix="${_target_prefix}" -Dtest.classlistfile=<(echo "${testlist}") -Dtest.timeout="${_test_timeout}" -Dtmp.dir="${TMP_DIR}" || echo "failed ${_target_prefix} ${_testlist_target}"
+    ant $_testlist_target -Dtest.classlistprefix="${_target_prefix}" -Dtest.classlistfile=<(echo "${testlist}") -Dtest.timeout="${_test_timeout}" -Dtmp.dir="${TMP_DIR}" -Dno-build-test=true || echo "failed ${_target_prefix} ${_testlist_target}"
 }
 
 _main() {
@@ -151,7 +151,7 @@ _main() {
           echo Hacking jvm-dtest to run only first test found as no tests in split ${split_chunk} were found
           testlist="$( _list_tests "distributed"  | grep -v "upgrade" | head -n1)"
       fi
-      ant testclasslist -Dtest.classlistprefix=distributed -Dtest.timeout=$(_timeout_for "test.distributed.timeout") -Dtest.classlistfile=<(echo "${testlist}") -Dtmp.dir="${TMP_DIR}" || echo "failed $target"
+      ant testclasslist -Dtest.classlistprefix=distributed -Dtest.timeout=$(_timeout_for "test.distributed.timeout") -Dtest.classlistfile=<(echo "${testlist}") -Dtmp.dir="${TMP_DIR}" -Dno-build-test=true || echo "failed $target"
       ;;
     "jvm-dtest-upgrade")
       _build_all_dtest_jars
@@ -161,7 +161,7 @@ _main() {
           echo Hacking jvm-dtest-upgrade to run only first test found as no tests in split ${split_chunk} were found
           testlist="$( _list_tests "distributed"  | grep "upgrade" | head -n1)"
       fi
-      ant testclasslist -Dtest.classlistprefix=distributed -Dtest.timeout=$(_timeout_for "test.distributed.timeout") -Dtest.classlistfile=<(echo "${testlist}") -Dtmp.dir="${TMP_DIR}" || echo "failed $target"
+      ant testclasslist -Dtest.classlistprefix=distributed -Dtest.timeout=$(_timeout_for "test.distributed.timeout") -Dtest.classlistfile=<(echo "${testlist}") -Dtmp.dir="${TMP_DIR}" -Dno-build-test=true || echo "failed $target"
       ;;
     "cqlsh-test")
       ./pylib/cassandra-cqlsh-tests.sh $(pwd)


### PR DESCRIPTION
The flag is added: `-Dno-build-test=true`