### PR TITLE
Add foundation for independent parsing of junit based output for CI reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 dist/cassandra*
 .idea
 *.iml
+build-scripts/ci_parser/bin/
+build-scripts/ci_parser/lib/
+build-scripts/ci_parser/include/
+build-scripts/ci_parser/pyvenv.cfg
 

--- a/build-scripts/ci_parser/.flake8
+++ b/build-scripts/ci_parser/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+# E501: Don't abuse long lines, but also... meh
+# F401: flake8 isn't smart enough to see type hints in comments post declaration
+ignore = E501, F401

--- a/build-scripts/ci_parser/ci_parser.py
+++ b/build-scripts/ci_parser/ci_parser.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+
+"""
+Script to take an arbitrary root directory of subdirectories of junit output format and create a summary .html file
+with their results.
+"""
+
+import argparse
+import cProfile
+import pstats
+import os
+import shutil
+import tarfile
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, Dict, List, IO, Optional, Tuple, Type
+from pathlib import Path
+
+from junit_helpers import JUnitResultBuilder, JUnitTestCase, JUnitTestSuite, JUnitTestStatus, LOG_FILE_NAME
+from logging_helper import build_logger, mute_logging, CustomLogger
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print('bs4 not installed; make sure you have bs4 in your active python env.')
+    exit(1)
+
+
+parser = argparse.ArgumentParser(description="""
+Parses ci results provided ci output in input path and generates html
+results in specified output file. Expects an existing .html file to insert
+results into; this file will be backed up into a <file_name>.bak file in its
+local directory.
+""")
+parser.add_argument('--input', type=str, help='path to input files (recursive directory search for *.xml)')
+# TODO: Change this paradigm to a full "input dir translates into output file", where output file includes some uuid
+# We'll need full support for all job types, not just junit, which will also necessitate refactoring into some kind of
+# TestResultParser, of which JUnit would be one type. But there's a clear pattern here we can extract. Thinking checkstyle.
+parser.add_argument('--output', type=str, help='existing .html output file to append to')
+parser.add_argument('--mute', action='store_true', help='mutes stdout and only logs to log file')
+parser.add_argument('--profile', '-p', action='store_true', help='Enable perf profiling on operations')
+parser.add_argument('-v', '-d', '--verbose', '--debug', dest='debug', action='store_true', help='verbose log output')
+args = parser.parse_args()
+if args.input is None or args.output is None:
+    parser.print_help()
+    exit(1)
+
+logger = build_logger(LOG_FILE_NAME, args.debug)  # type: CustomLogger
+if args.mute:
+    mute_logging(logger)
+
+
+def main():
+    check_file_condition(lambda: os.path.exists(args.input), f'Cannot find {args.input}. Aborting.')
+    check_file_condition(lambda: os.path.exists(args.output), 'This mode is designed to insert a table into an existing .html file. Cannot proceed.')
+    test_suites = extract_junit_from_test_run(args.input)
+    for suite in test_suites.values():
+        logger.info(f'Suite: {suite.name()}')
+        logger.info(f'-- Passed: {suite.passed()}')
+        logger.info(f'-- Failure: {suite.failed()}')
+        logger.info(f'-- Skipped: {suite.skipped()}')
+        if suite.is_empty() and suite.file_count() == 0:
+            logger.warning(f'Have an empty test_suite: {suite.name()} that had no .xml files associated with it. Did the jobs run correctly and produce junit files? Check {suite.get_archive()} for test run command result details.')
+        elif suite.is_empty():
+            logger.warning(f'Got an unexpected empty test_suite: {suite.name()} with no .xml file parsing associated with it. Check {LOG_FILE_NAME}.log when run with -v for details.')
+    append_failure_results(test_suites, args.output)
+
+
+def extract_junit_from_test_run(input_dir: str) -> Dict[str, JUnitTestSuite]:
+    """
+    For a given input input_dir, will find all .gz files in that tree, extract files from them preserving input_dir structure
+    and parse out all found junit test results into the global test result containers.
+    :param input_dir: Input directory to recursively search for .gz files
+    """
+
+    # Skip archives that we know exist but don't have results we want.
+    gz_exclusions = ['split', 'result_details']
+
+    # Inclusions win over exclusions right now but are empty by default.
+
+    # TODO: Make this a command-line regex? Used for debugging; could use to parse just a certain subset of suites.
+    gz_inclusions = None  # type: Optional[List[str]]
+    # gz_inclusions = ['python']
+
+    # TODO: Make this a command-line debug flag? Used for debugging
+    debug_file = None  # type: Optional[str]
+    # debug_file = 'jvm17-utests_archive.tar.gz'
+    if debug_file is not None:
+        gz_files = [str(file) for file in Path(input_dir).rglob('*.gz') if debug_file in str(file)]
+    elif gz_inclusions is not None:
+        gz_files = [str(file) for file in Path(input_dir).rglob('*.gz') if any(x in str(file) for x in gz_inclusions)]
+    else:
+        gz_files = [str(file) for file in Path(input_dir).rglob('*.gz') if not any(x in str(file) for x in gz_exclusions)]
+    check_file_condition(lambda: len(gz_files) != 0, f'Found 0 .gz files in path: {input_dir}. Cannot proceed with .xml extraction.')
+    logger.debug(f'Extracting .xml from {len(gz_files)} gzip files from path: {input_dir}')
+
+    archive_count = 0
+    test_file_count = 0
+    test_count = 0
+
+    test_suites = dict()  # type: Dict[str, JUnitTestSuite]
+
+    logger.info('List of gzip files to be processed:')
+    for file in gz_files:
+        logger.info(f' -- {file}')
+
+    # Since we have a 1:1 ratio on .gz files to suites, we can parallelize w/out any kind of synchronization. We also
+    # check to ensure this contract is upheld in the processing method.
+    with ThreadPoolExecutor() as executor:
+        futures = [executor.submit(process_gzip_file, gz_file, input_dir, test_suites) for gz_file in gz_files]
+        for future in as_completed(futures):
+            exception = future.exception()
+            if exception is not None:
+                logger.critical('Saw an exception processing .gzip file. Aborting.')
+                raise exception
+            else:
+                files, tests = future.result()
+                test_file_count += files
+                test_count += tests
+
+    logger.progress(f'Total archive count: {archive_count}')
+    logger.progress(f'Total junit file count: {test_file_count}')
+    logger.progress(f'Total suite count: {len(test_suites.keys())}')
+    logger.progress(f'Total test count: {test_count}')
+    passed = 0
+    failed = 0
+    skipped = 0
+
+    for suite in test_suites.values():
+        passed += suite.passed()
+        failed += suite.failed()
+        if suite.failed() != 0:
+            print_errors(suite)
+        skipped += suite.skipped()
+
+    logger.progress(f'-- Passed: {passed}')
+    logger.progress(f'-- Failed: {failed}')
+    logger.progress(f'-- Skipped: {skipped}')
+    return test_suites
+
+
+def process_gzip_file(gz_file: str, input_dir: str, test_suites: Dict[str, JUnitTestSuite]) -> Tuple[int, int]:
+    """
+    Pretty straightforward here - we unpack all our .gz files, walk through any .xml files in there and look for tests,
+    parsing them out into our global JUnitTestCase Dicts as we find them
+
+    No thread safety on target Dict -> relying on the "one .gz per suite" rule to keep things clean
+
+    This takes place in the context of an executor thread
+    :return: Tuple[file count, test count]
+    """
+    # Leading part of non-root portion of path needs to correlate to job / pipeline name. We'll group by those.
+    logger.debug(f'Replacing input_dir: {input_dir} in path: {gz_file}.')
+    suite_name = gz_file.replace(input_dir, '').lstrip('/').split('/')[0]
+    logger.progress(f'Processing archive: {gz_file} for test suite: {suite_name}')
+
+    # And make sure we're not racing
+    if suite_name in test_suites:
+        log_and_raise(f'Got a duplicate suite_name - this will lead to race conditions. Suite: {suite_name}. gz file: {gz_file}. Aborting', AssertionError)
+    else:
+        test_suites[suite_name] = JUnitTestSuite(suite_name)
+
+    active_suite = test_suites[suite_name]
+    # Store this for later logging if we have a failed job; help the user know where to look next.
+    active_suite.set_archive(gz_file)
+    active_file = ''
+    test_file_count = 0
+    test_count = 0
+    try:
+        with tarfile.open(gz_file, 'r:gz') as tar:
+            # Since we can theoretically have duplicate members of .xml files modified at different times, we build up a
+            # list of whatever the latest sequential member of any .xml file is and then use that.
+            for member in tar.getmembers():
+                if '.xml' in member.name:
+                    file_name = member.name.split('/')[-1]
+                    active_file = file_name
+                    fc = extract_test_cases(active_suite, file_name, tar.extractfile(member))
+                    if fc != 0:
+                        test_file_count += 1
+                        test_count += fc
+    except EOFError:
+        logger.error(f'EOFError on {gz_file}. Skipping; will be missing results for {suite_name}')
+        return 0, 0
+    except Exception as e:
+        logger.critical(f'Got unexpected error while parsing {gz_file} on file: {active_file}: {e}. Aborting.')
+        raise e
+    return test_file_count, test_count
+
+
+def print_errors(suite: JUnitTestSuite) -> None:
+    logger.warning(f'\n[Printing {suite.failed()} tests from suite: {suite.name()}]')
+    for testcase in suite.get_tests(JUnitTestStatus.FAILURE):
+        logger.warning(f'{testcase}')
+
+
+def extract_test_cases(suite: JUnitTestSuite, file_name: str, file_contents: Optional[IO[bytes]]) -> int:
+    """
+    For a given input .xml, will extract all JUnitTestCase matching objects and store them in the global registry keyed off
+    suite name.
+
+    Called in context of executor thread.
+    :param suite: The JUnitTestSuite object we're currently working with
+    :param file_name: .xml file_name to check for tests. May or may not be junit format.
+    :param file_contents: uncompressed file contents to read .xml from
+    :return : count of tests extracted from this file_name
+    """
+    xml_exclusions = ['logback', 'checkstyle']
+    if any(x in file_name for x in xml_exclusions):
+        return 0
+
+    # TODO: In extreme cases (python upgrade dtests), this could theoretically be a HUGE file we're materializing in memory. Consider .iterparse or tag sanitization using sed first.
+    root = ET.parse(file_contents).getroot()  # type: ignore
+
+    # Search inside entire hierarchy since sometimes it's at the root and sometimes one level down.
+    test_count = len(root.findall('.//testcase'))
+    if test_count == 0:
+        logger.warning(f'Appear to be processing an .xml file without any junit tests in it: {file_name}. Update .xml exclusions to exclude this.')
+        if args.debug:
+            logger.info(ET.tostring(root))
+        return 0
+
+    suite.add_file(file_name)
+    found = 0
+    for testcase in root.iter('testcase'):
+        processed = JUnitTestCase(testcase)
+        suite.add_testcase(processed)
+        found = 1
+    if found == 0:
+        logger.error(f'file: {file_name} has test_count: {test_count} but root.iter iterated across nothing!')
+        logger.error(ET.tostring(root))
+    return test_count
+
+
+# TODO: Update this to instead be "create_summary_file" and build the entire summary page, not just append failures to existing
+# This should be trivial to do using JUnitTestSuite.failed, passed, etc methods
+def append_failure_results(test_suites: Dict[str, JUnitTestSuite], output: str) -> None:
+    """
+    Will create a table with all failed tests in it organized by sorted suite name.
+    :param test_suites: Collection of JUnitTestSuite's parsed out pass/fail data
+    :param output: Path to the .html we want to append to the <body> of
+    """
+    with open(output, 'r') as file:
+        soup = BeautifulSoup(file, 'html.parser')
+
+    new_tag = soup.new_tag("div", style="font-size: 22px; color: white; font-weight: bold;")
+    new_tag.string = '[Test Failure Details]'
+    soup.body.append(new_tag)
+    JUnitResultBuilder.add_style_tags(soup)
+
+    # We cut off at 200 failures; if you have > than that chances are you have a bad run and there's no point in
+    # just continuing to pollute the summary file with it and blow past file size. Since the inlined failures are
+    # a tool to be used in the attaching / review process and not primarily workflow and fixing.
+    total_failure_count = 0
+    for suite_name in sorted(test_suites.keys()):
+        suite = test_suites[suite_name]
+        failure_count = suite.count(JUnitTestStatus.FAILURE)
+        if failure_count == 0:
+            # Don't append anything to results in the happy path case.
+            logger.debug(f'No failed tests in suite: {suite_name}')
+        else:
+            # Else independent table per suite.
+            builder = JUnitResultBuilder(suite_name, failure_count)
+            builder.label_columns(JUnitTestCase.headers())
+            for test in suite.get_tests(JUnitTestStatus.FAILURE):
+                builder.add_row(test.row_data())
+            table_data = BeautifulSoup(builder.build_table(), 'html.parser')
+            soup.append(table_data)
+        total_failure_count += failure_count
+        # TODO: Consider making 200 configurable via a command-line flag if we find this is useful for local debugging work.
+        if total_failure_count > 200:
+            logger.critical(f'Saw {total_failure_count} failures; greater than 200 threshold. Not appending further failure details to {output}.')
+            break
+
+    # Only backup the output file if we've gotten this far
+    shutil.copyfile(output, output + '.bak')
+
+    # We write w/formatter set to None as invalid char above our insertion in the input file we're modifying (from other
+    # tests, test output, etc) can cause the parser to get very confused and do Bad Things.
+    with open(output, 'w') as file:
+        file.write(soup.prettify(formatter=None))
+    logger.progress(f'Test failure details appended to file: {output}')
+
+
+def check_file_condition(function: Callable[[], bool], msg: str) -> None:
+    """
+    Specifically raises a FileNotFoundError if something's wrong with the Callable
+    """
+    if not function():
+        log_and_raise(msg, FileNotFoundError)
+
+
+def log_and_raise(msg: str, error_type: Type[BaseException]) -> None:
+    logger.critical(msg)
+    raise error_type(msg)
+
+
+if __name__ == "__main__" and args.profile:
+    profiler = cProfile.Profile()
+    profiler.enable()
+    main()
+    profiler.disable()
+    stats = pstats.Stats(profiler).sort_stats('cumulative')
+    stats.print_stats()
+else:
+    main()

--- a/build-scripts/ci_parser/junit_helpers.py
+++ b/build-scripts/ci_parser/junit_helpers.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+
+"""
+In-memory representations of JUnit test results and some helper methods to construct .html output
+based on those results
+"""
+
+import logging
+import xml.etree.ElementTree as ET
+
+from bs4 import BeautifulSoup
+from enum import Enum
+from jinja2 import Template
+from typing import Any, Dict, Iterable, List, Set, Tuple
+
+LOG_FILE_NAME = 'junit_parsing'
+logger = logging.getLogger(LOG_FILE_NAME)
+
+
+class JUnitTestStatus(Enum):
+    label: str
+
+    """
+    Map to the string tag expected in the child element in junit output
+    """
+    UNKNOWN = (0, 'unknown')
+    PASSED = (1, 'passed')
+    FAILURE = (2, 'failure')
+    SKIPPED = (3, 'skipped')
+    # Error and FAILURE are unfortunately used interchangeably by some of our suites, so we combine them on parsing
+    ERROR = (4, 'error')
+
+    def __new__(cls, value, label) -> Any:
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.label = label
+        return obj
+
+    def __str__(self):
+        return self.label
+
+    @staticmethod
+    def html_cell_order() -> Tuple:
+        """
+        We won't have UNKNOWN, and ERROR is merged into FAILURE. This is our preferred order to represent things in html.
+        """
+        return JUnitTestStatus.FAILURE, JUnitTestStatus.PASSED, JUnitTestStatus.SKIPPED
+
+
+class JUnitResultBuilder:
+    """
+    Wraps up jinja templating for our junit based results. Manually doing this stuff was proving to be a total headache.
+    That said, this didn't turn out to be a picnic on its own either. The particularity of .html parsing and this
+    templating combined with BeautifulSoup means things are... very very particular. Bad parsing on things from the .sh
+    or other sources can make bs4 replace things in weird ways.
+    """
+    def __init__(self, name: str, failures: int) -> None:
+        self._name = name
+        self._failures = failures
+        self._labels = []  # type: List[str]
+        self._rows = []  # type: List[List[str]]
+        self._header = ['unknown', 'unknown', 'unknown', 'unknown']
+
+        # Have to have the 4 <th> members since the stylesheet formats them based on position and it'll get all stupid
+        # otherwise.
+        self._template = Template('''
+        <table class="table-fixed">
+          <tr style = "height: 18px; background-color: black; color: white;">
+            <th> {{header}} </th>
+            <th></th>
+            <th></th>
+            <th></th>
+          </tr>
+          <tr>
+            <th>{{ labels[0] }}</td>
+            <th>{{ labels[1] }}</td>
+            <th>{{ labels[2] }}</td>
+            <th>{{ labels[3] }}</td>
+          </tr>
+          {% for row in rows %}
+          <tr>
+            <td>{{ row[0] }}</td>
+            <td>{{ row[1] }}</td>
+            <td>{{ row[2] }}</td>
+            <td>{{ row[3] }}</td>
+          </tr>
+          {% endfor %}
+        </table>
+        ''')
+
+    @staticmethod
+    def add_style_tags(soup: BeautifulSoup) -> None:
+        """
+        We want to be opinionated about the width of our tables for our test suites; the messages dominate the output
+        so we want to dedicate the largest amount of space to them and limit word-wrapping
+        """
+        style_tag = soup.new_tag("style")
+        style_tag.string = """
+        .table-fixed {
+            table-layout: fixed;
+            width: 100%;
+        }
+        .table-fixed th:nth-child(1), .table-fixed td:nth-child(1),
+        .table-fixed th:nth-child(2), .table-fixed td:nth-child(2) {
+            width: 15%;
+            text-align: left;
+            word-break: break-all;
+        }
+        .table-fixed th:nth-child(3), .table-fixed td:nth-child(3) {
+            width: 60%;
+            text-align: left;
+        }
+        .table-fixed th:nth-child(4), .table-fixed td:nth-child(4) {
+            width: 10%;
+            text-align: right;
+        }
+        """
+        soup.head.append(style_tag)
+
+    def label_columns(self, cols: List[str]) -> None:
+        if len(cols) != 4:
+            raise AssertionError(f'Got invalid number of columns on label_columns: {len(cols)}. Expected: 4.')
+        self._labels = cols
+
+    def add_row(self, row: List[str]) -> None:
+        if len(row) != 4:
+            raise AssertionError(f'Got invalid number of columns on add_row: {len(row)}. Expected: 4.')
+        self._rows.append(row)
+
+    def build_table(self) -> str:
+        return self._template.render(header=f'{self._name} failures: {self._failures}', labels=self._labels, rows=self._rows)
+
+
+class JUnitTestCase:
+    """
+    Pretty straightforward in-memory representation of the state of a jUnit test. Not the _most_ tolerant of bad input,
+    so don't test your luck.
+    """
+    def __init__(self, testcase: ET.Element) -> None:
+        """
+        From a given xml element, constructs a junit testcase. Doesn't do any sanity checking to make sure you gave
+        it something correct, so... don't screw up.
+
+        Here's our general junit formatting:
+
+        <testcase classname = "org.apache.cassandra.index.sai.cql.VectorUpdateDeleteTest" name = "updateTest-_jdk11" time = "0.314">
+            <failure message = "Result set does not contain a row with pk = 0" type = "junit.framework.AssertionFailedError">
+            # The following is stored in failure.text:
+            DETAILED ERROR MESSAGE / STACK TRACE
+            DETAILED ERROR MESSAGE / STACK TRACE
+            ...
+            </failure>
+        </testcase>
+
+        And our skipped format:
+        <testcase classname="org.apache.cassandra.distributed.test.PreviewRepairCoordinatorFastTest" name="snapshotFailure[PARALLEL/true]-_jdk11" time="0.218">
+          <skipped message="Parallel repair does not perform snapshots" />
+        </testcase>
+
+        Same for errors
+
+        We conflate the <error and <failure sub-elements in our junit failures and will need to combine those on processing.
+        """
+        if testcase is None:
+            raise AssertionError('Got an empty testcase; cannot create JUnitTestCase from nothing.')
+        # No point in including the whole long o.a.c. thing. At least for now. This could bite us later if we end up with
+        # other pathed test cases but /shrug
+        self._class_name = testcase.get('classname', '').replace('org.apache.cassandra.', '')  # type: str
+        self._test_name = testcase.get('name', '')  # type: str
+        self._message = 'Passed'  # type: str
+        self._status = JUnitTestStatus.PASSED  # type: JUnitTestStatus
+        self._time = testcase.get('time', '')  # type: str
+
+        # For the current set of tests, we don't have > 1 child tag indicating something went wrong. So we check to ensure
+        # that remains true and will assert out if we hit something unexpected.
+        saw_error = 0
+
+        def _check_for_child_element(failure_type: JUnitTestStatus) -> None:
+            """
+            The presence of any failure, error, or skipped child elements indicated this test wasn't a normal 'pass'.
+            We want to extract the message from the child if it has one as well as update the status of this object,
+            including glomming together ERROR and FAILURE cases here. We combine those two as some legit test failures
+            are reported as <error /> in the pytest cases.
+            """
+            nonlocal testcase
+            child = testcase.find(failure_type.label)
+            if child is None:
+                return
+
+            nonlocal saw_error
+            if saw_error != 0:
+                raise AssertionError(f'Got a test with > 1 "bad" state (error, failed, skipped). classname: {self._class_name}. test: {self._test_name}.')
+            saw_error = 1
+
+            # We don't know if we're going to have message attribute data, text attribute, or text inside our tag. So
+            # we just connect all three
+            final_msg = '-'.join(filter(None, (child.get('message'), child.get('text'), child.text)))
+
+            self._message = final_msg
+            if failure_type == JUnitTestStatus.ERROR or failure_type == JUnitTestStatus.FAILURE:
+                self._status = JUnitTestStatus.FAILURE
+            else:
+                self._status = failure_type
+
+        _check_for_child_element(JUnitTestStatus.FAILURE)
+        _check_for_child_element(JUnitTestStatus.ERROR)
+        _check_for_child_element(JUnitTestStatus.SKIPPED)
+
+    @staticmethod
+    def headers() -> List[str]:
+        return ['Class', 'Method', 'Output', 'Duration']
+
+    def row_data(self) -> List[str]:
+        return [self._class_name, self._test_name, self._message, str(self._time)]
+
+    def status(self) -> JUnitTestStatus:
+        return self._status
+
+    def message(self) -> str:
+        return self._message
+
+    def __hash__(self) -> int:
+        """
+        We want to allow overwriting of existing combinations of class + test names, since our tarballs of results will
+        have us doing potentially duplicate sequential processing of files and we just want to keep the most recent one.
+        Of note, sorting the tarball contents and trying to navigate to and find the oldest and only process that was
+        _significantly_ slower than just brute-force overwriting this way. Like... I gave up after 10 minutes vs. < 1 second.
+        """
+        return hash((self._class_name, self._test_name))
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, JUnitTestCase):
+            return (self._class_name, self._test_name) == (other._class_name, other._test_name)
+        return NotImplemented
+
+    def __str__(self) -> str:
+        """
+        We slice the message here; don't rely on this for anything where you need full reporting
+        :return:
+        """
+        clean_msg = self._message.replace('\n', ' ')
+        return (f"JUnitTestCase(class_name='{self._class_name}', "
+                f"name='{self._test_name}', msg='{clean_msg[:50]}', "
+                f"time={self._time}, status={self._status.name})")
+
+
+class JUnitTestSuite:
+    """
+    Straightforward container for a set of tests.
+    """
+
+    def __init__(self, name: str):
+        self._name = name  # type: str
+        self._suites = dict()  # type: Dict[JUnitTestStatus, Set[JUnitTestCase]]
+        self._files = set()  # type: Set[str]
+        # We only allow one archive to be associated with each JUnitTestSuite
+        self._archive = 'unknown'  # type: str
+        for status in JUnitTestStatus:
+            self._suites[status] = set()
+
+    def add_testcase(self, newcase: JUnitTestCase) -> None:
+        """
+        Replaces if existing is found.
+        """
+        if newcase.status() == JUnitTestStatus.UNKNOWN:
+            raise AssertionError(f'Attempted to add a testcase with an unknown status: {newcase}. Aborting.')
+        self._suites[newcase.status()].discard(newcase)
+        self._suites[newcase.status()].add(newcase)
+
+    def get_tests(self, status: JUnitTestStatus) -> Iterable[JUnitTestCase]:
+        """
+        Returns sorted list of tests, class name first then test name
+        """
+        return sorted(self._suites[status], key=lambda x: (x._class_name, x._test_name))
+
+    def passed(self) -> int:
+        return self.count(JUnitTestStatus.PASSED)
+
+    def failed(self) -> int:
+        return self.count(JUnitTestStatus.FAILURE)
+
+    def skipped(self) -> int:
+        return self.count(JUnitTestStatus.SKIPPED)
+
+    def count(self, status: JUnitTestStatus) -> int:
+        return len(self._suites[status])
+
+    def name(self) -> str:
+        return self._name
+
+    def is_empty(self) -> bool:
+        return self.passed() == 0 and self.failed() == 0 and self.skipped() == 0
+
+    def set_archive(self, name: str) -> None:
+        if self._archive != "unknown":
+            msg = f'Attempted to set archive for suite: {self._name} when archive already set: {self._archive}. This is a bug.'
+            logger.critical(msg)
+            raise AssertionError(msg)
+        self._archive = name
+
+    def get_archive(self) -> str:
+        return self._archive
+
+    def add_file(self, name: str) -> None:
+        # Just silently noop if we already have one since dupes in tarball indicate the same thing effectively. That we have it.
+        self._files.add(name)
+
+    def file_count(self) -> int:
+        """
+        Returns count of _unique_ files associated with this suite, not necessarily the _absolute_ count of files, since
+        we don't bother keeping count of multiple instances of a .xml file in the tarball.
+        :return:
+        """
+        return len(self._files)
+
+    @staticmethod
+    def headers() -> List[str]:
+        result = ['Suite']
+        for status in JUnitTestStatus.html_cell_order():
+            result.append(status.name)
+        return result

--- a/build-scripts/ci_parser/logging.sh
+++ b/build-scripts/ci_parser/logging.sh
@@ -1,0 +1,108 @@
+export TEXT_RED="0;31"
+export TEXT_GREEN="0;32"
+export TEXT_LIGHTGREEN="1;32"
+export TEXT_BROWN="0;33"
+export TEXT_YELLOW="1;33"
+export TEXT_BLUE="0;34"
+export TEXT_LIGHTBLUE="1;34"
+export TEXT_PURPLE="0;35"
+export TEXT_LIGHTPURPLE="1;35"
+export TEXT_CYAN="0;36"
+export TEXT_LIGHTCYAN="1;36"
+export TEXT_LIGHTGRAY="0;37"
+export TEXT_WHITE="1;37"
+export TEXT_DARKGRAY="1;30"
+export TEXT_LIGHTRED="1;31"
+
+export SILENCE_LOGGING=false
+export LOG_TO_FILE="${LOG_TO_FILE:-false}"
+
+disable_logging() {
+  export SILENCE_LOGGING=true
+}
+
+enable_logging() {
+  export SILENCE_LOGGING=false
+}
+
+echo_color() {
+  if [[ $LOG_TO_FILE == "true" ]]; then
+    echo "$1"
+  elif [[ $SILENCE_LOGGING != "true" ]]; then
+    echo -e "\033[1;${2}m${1}\033[0m"
+  fi
+}
+
+log_header() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    log_separator
+    echo_color "$1" $TEXT_GREEN
+    log_separator
+  fi
+}
+
+log_progress() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "$1" $TEXT_LIGHTCYAN
+  fi
+}
+
+log_info() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "$1" $TEXT_LIGHTGRAY
+  fi
+}
+
+log_quiet() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "$1" $TEXT_DARKGRAY
+  fi
+}
+
+# For transient always-on debugging
+log_transient() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "[TRANSIENT]: $1" $TEXT_BROWN
+  fi
+}
+
+# For durable user-selectable debugging
+log_debug() {
+  if [[ "$SILENCE_LOGGING" = "true" ]]; then
+    return
+  fi
+
+  if [[ "${DEBUG:-false}" == true || "${DEBUG_LOGGING:-false}" == true ]]; then
+    echo_color "[DEBUG] $1" $TEXT_PURPLE
+  fi
+}
+
+log_quiet() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "$1" $TEXT_LIGHTGRAY
+  fi
+}
+
+log_todo() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "TODO: $1" $TEXT_LIGHTPURPLE
+  fi
+}
+
+log_warning() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "WARNING: $1" $TEXT_YELLOW
+  fi
+}
+
+log_error() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "ERROR: $1" $TEXT_RED
+  fi
+}
+
+log_separator() {
+  if [[ $SILENCE_LOGGING != "true" ]]; then
+    echo_color "--------------------------------------------" $TEXT_GREEN
+  fi
+}

--- a/build-scripts/ci_parser/logging_helper.py
+++ b/build-scripts/ci_parser/logging_helper.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+"""
+We want to add a little functionality on top of built-in logging; colorization, some new log levels, and logging
+to a file built-in as well as some other conveniences.
+"""
+
+import logging
+import threading
+from enum import Enum
+from logging import Logger
+from logging.handlers import RotatingFileHandler
+
+
+PROGRESS_LEVEL_NUM = 25
+SECTION_LEVEL_NUM = 26
+logging.addLevelName(PROGRESS_LEVEL_NUM, 'PROGRESS')
+logging.addLevelName(SECTION_LEVEL_NUM, 'SECTION')
+
+
+class LogLevel(Enum):
+    """
+    Matches logging.<VALUE> int levels; wrapped in enum here for convenience
+    """
+    CRITICAL = 50
+    FATAL = CRITICAL
+    ERROR = 40
+    WARNING = 30
+    WARN = WARNING
+    INFO = 20
+    DEBUG = 10
+    NOTSET = 0
+
+
+class CustomLogger(Logger):
+    # Some decorations to match the paradigm used in some other .sh files
+    def progress(self, message: str, *args, **kws) -> None:
+        if self.isEnabledFor(PROGRESS_LEVEL_NUM):
+            self._log(PROGRESS_LEVEL_NUM, message, args, **kws)
+
+    def separator(self, *args, **kws) -> None:
+        if self.isEnabledFor(logging.DEBUG) and self.isEnabledFor(SECTION_LEVEL_NUM):
+            self._log(SECTION_LEVEL_NUM, '-----------------------------------------------------------------------------', args, **kws)
+
+    def header(self, message: str, *args, **kws) -> None:
+        if self.isEnabledFor(logging.DEBUG) and self.isEnabledFor(SECTION_LEVEL_NUM):
+            self._log(SECTION_LEVEL_NUM, f'----[{message}]----', args, **kws)
+
+
+logging.setLoggerClass(CustomLogger)
+LOG_FORMAT_STRING = '%(asctime)s - [tid:%(threadid)s] - [%(levelname)s]::%(message)s'
+
+
+def build_logger(name: str, verbose: bool) -> CustomLogger:
+    logger = CustomLogger(name)
+    logger.setLevel(logging.INFO)
+    logger.addFilter(ThreadContextFilter())
+
+    stdout_handler = logging.StreamHandler()
+    file_handler = RotatingFileHandler(f'{name}.log')
+
+    formatter = CustomFormatter()
+    stdout_handler.setFormatter(formatter)
+    # Don't want color escape characters in our file logging, so we just use the string rather than the whole formatter
+    file_handler.setFormatter(logging.Formatter(LOG_FORMAT_STRING))
+
+    logger.addHandler(stdout_handler)
+    logger.addHandler(file_handler)
+
+    if verbose:
+        logger.setLevel(logging.DEBUG)
+
+    # Prevent root logger propagation from duplicating results
+    logger.propagate = False
+    return logger
+
+
+def set_loglevel(logger: logging.Logger, level: LogLevel) -> None:
+    if logger.handlers:
+        for handler in logger.handlers:
+            handler.setLevel(level.value)
+
+
+def mute_logging(logger: logging.Logger) -> None:
+    if logger.handlers:
+        for handler in logger.handlers:
+            handler.setLevel(logging.CRITICAL + 1)
+
+
+# Since we'll thread, let's point out threadid in our format
+class ThreadContextFilter(logging.Filter):
+    def filter(self, record):
+        record.threadid = threading.get_ident()
+        return True
+
+
+class CustomFormatter(logging.Formatter):
+    grey = "\x1b[38;21m"
+    blue = "\x1b[34;21m"
+    green = "\x1b[32;21m"
+    yellow = "\x1b[33;21m"
+    red = "\x1b[31;21m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
+    purple = "\x1b[35m"
+
+    FORMATS = {
+        PROGRESS_LEVEL_NUM: blue + LOG_FORMAT_STRING + reset,
+        SECTION_LEVEL_NUM: green + LOG_FORMAT_STRING + reset,
+        logging.DEBUG: purple + LOG_FORMAT_STRING + reset,
+        logging.INFO: grey + LOG_FORMAT_STRING + reset,
+        logging.WARNING: yellow + LOG_FORMAT_STRING + reset,
+        logging.ERROR: red + LOG_FORMAT_STRING + reset,
+        logging.CRITICAL: bold_red + LOG_FORMAT_STRING + reset
+    }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno, self.format)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)

--- a/build-scripts/ci_parser/mypy.ini
+++ b/build-scripts/ci_parser/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/build-scripts/ci_parser/precommit_check.sh
+++ b/build-scripts/ci_parser/precommit_check.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+source "logging.sh"
+
+skip_mypy=(
+    "./logging_helper.py"
+)
+
+failed=0
+log_progress "Linting ci_parser..."
+for i in `find . -maxdepth 1 -name "*.py"`; do
+    log_progress "Checking $i..."
+    flake8 "$i"
+    if [[ $? != 0 ]]; then
+        failed=1
+    fi
+
+    if [[ ! " ${skip_mypy[*]} " =~ ${i} ]]; then
+        mypy --ignore-missing-imports "$i"
+        if [[ $? != 0 ]]; then
+            failed=1
+        fi
+    fi
+done
+
+
+if [[ $failed -eq 1 ]]; then
+    log_error "Failed linting. See above errors; don't merge until clean."
+    exit 1
+else
+    log_progress "All scripts passed checks"
+    exit 0
+fi

--- a/build-scripts/ci_parser/requirements.txt
+++ b/build-scripts/ci_parser/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+jinja2


### PR DESCRIPTION
This adds a python based xunit format parser. I originally wrote it for inserting failures into the ci_summary.html results from internal ci, however I plan to extend it to also generate the entire thing. Since generating _anything_ in bash is not something I ever want to do again.

Extension to generate the entire ci_summary would need the following new information:
* git branch name for C*, ccm, dtest (as needed for the latter 2)
* sha built (+ccm and dtest as needed)
* checkstyle and dep status

And need the following existing information (inside JUnitTestSuite class in python):
* per suite, total tests, passed, skipped, failed, errors. Though we will need to tweak things so the failure and error types don't get glommed together (python and jvm tests treat the term differently I think?)