### PR TITLE
CASSJAVA-25: Build a public CI for Apache Cassandra Java Driver

### DIFF
--- a/docker/testing/ubuntu2204_java_driver_testing.docker
+++ b/docker/testing/ubuntu2204_java_driver_testing.docker
@@ -42,15 +42,24 @@ RUN . /home/docker/.jabba/jabba.sh && jabba install openjdk@17
 ENV PATH="/home/docker/.jabba/bin:/home/docker/.local/bin:$PATH"
 
 RUN echo "export JAVA8_HOME=$(jabba which openjdk@1.8.0-292)" >> ~/env.txt && \
-      echo "export JAVA11_HOME=$(jabba which openjdk@1.11.0-9)" >> ~/env.txt && \
+    echo "export JAVA11_HOME=$(jabba which openjdk@1.11.0-9)" >> ~/env.txt && \
     echo "export JAVA17_HOME=$(jabba which openjdk@17)" >> ~/env.txt && \
-      echo "export JAVA_HOME=$(jabba which openjdk@1.8.0-292)" >> ~/env.txt && \
-      echo ". $HOME/.jabba/jabba.sh" >> ~/env.txt && \
-      echo "jabba use openjdk@1.8.0-292" >> ~/env.txt
+    echo "export JAVA_HOME=$(jabba which openjdk@1.8.0-292)" >> ~/env.txt && \
+    echo ". $HOME/.jabba/jabba.sh" >> ~/env.txt && \
+    echo "jabba use openjdk@1.8.0-292" >> ~/env.txt
 
 # ccm
 RUN git clone https://github.com/riptano/ccm.git  && \
     cd ccm && \
     pip install -e .
+
+# download cassandra binaries of latest patch versions for each minor version
+RUN curl -s https://downloads.apache.org/cassandra/ | \
+    grep -oP '(?<=href=\")[0-9]+\.[0-9]+\.[0-9]+(?=)' | \
+    sort -rV | \
+    uniq -w 3 | \
+    while read -r version; do \
+        ccm create --quiet -n 1 -v binary:"$version" test && ccm remove test ; \
+    done
 
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ]

--- a/jenkins-dsl/cassandra_job_dsl_seed.groovy
+++ b/jenkins-dsl/cassandra_job_dsl_seed.groovy
@@ -1480,6 +1480,11 @@ multibranchPipelineJob('cassandra-java-driver') {
             repoOwner('apache')
               repository('cassandra-java-driver')
         }
+        buildStrategies {
+            buildChangeRequests {
+                ignoreTargetOnlyChanges(true)
+            }
+        }
     }
       factory {
         workflowBranchProjectFactory {


### PR DESCRIPTION
1. Add ignoreTargetOnlyChanges(true) so that PRs do not automatically rerun every time target branch is updated
2. Download cassandra binaries when building docker images so that `ccm create` will not time out
Will need to install plugin [Basic Branch Build Strategies](https://plugins.jenkins.io/basic-branch-build-strategies/) to ci-cassandra jenkins server.