### PR TITLE
In contribulyze automate the all components grouping to be all repositories

### DIFF
--- a/contribulyze/contribulyze.sh
+++ b/contribulyze/contribulyze.sh
@@ -13,10 +13,10 @@ mkdir -p /tmp/contribulyze-repos
 mkdir -p /tmp/contribulyze-html
 cd /tmp/contribulyze-repos
 
-repos=("https://github.com/apache/cassandra.git" "https://github.com/apache/cassandra-dtest.git" "https://github.com/apache/cassandra-builds.git" "https://github.com/apache/cassandra-in-jvm-dtest-api.git" "https://github.com/apache/cassandra-harry.git" "https://github.com/apache/cassandra-website.git" "https://github.com/apache/cassandra-java-driver.git" "https://github.com/apache/cassandra-gocql-driver.git" "https://github.com/datastax/python-driver.git" "https://github.com/apache/cassandra-sidecar.git" "https://github.com/apache/cassandra-analytics.git" "https://github.com/apache/cassandra-accord.git" "https://github.com/apache/cassandra-ccm" "https://github.com/apache/cassandra-spark-connector")
+repos=("https://github.com/apache/cassandra.git" "https://github.com/apache/cassandra-dtest.git" "https://github.com/apache/cassandra-builds.git" "https://github.com/apache/cassandra-in-jvm-dtest-api.git" "https://github.com/apache/cassandra-harry.git" "https://github.com/apache/cassandra-website.git" "https://github.com/apache/cassandra-java-driver.git" "https://github.com/apache/cassandra-gocql-driver.git" "https://github.com/apache/cassandra-sidecar.git" "https://github.com/apache/cassandra-analytics.git" "https://github.com/apache/cassandra-accord.git" "https://github.com/apache/cassandra-ccm" "https://github.com/apache/cassandra-spark-connector")
 
 # the different groups we want separate contribulyze reports on. note '..' refers to everything.
-groups=('..' 'website_and_docs' 'build_and_tools' 'packaging_and_release' 'test_and_ci' 'cassandra_src' 'drivers' 'python-driver' 'cassandra-sidecar' 'cassandra-analytics' 'cassandra-accord')
+groups=('..' 'website_and_docs' 'build_and_tools' 'packaging_and_release' 'test_and_ci' 'cassandra_src' 'drivers' 'cassandra-sidecar' 'cassandra-analytics' 'cassandra-accord')
 
 for repo in ${repos[*]} ; do
     git clone --quiet ${repo}
@@ -59,11 +59,6 @@ for group in ${groups[*]} ; do
       groupings=("cassandra-java-driver" "cassandra-gocql-driver")
      ;;
 
-     "python-driver")
-      groupings=("python-driver")
-      continue # FIXME commit messages in python-driver do not follow the "patch by …; reviewed by … for CASSANDRA-" precedence
-     ;;
-
      "cassandra-sidecar")
       groupings=("cassandra-sidecar")
      ;;
@@ -77,7 +72,7 @@ for group in ${groups[*]} ; do
      ;;
 
      *)
-      groupings=("cassandra" "cassandra-dtest" "cassandra-in-jvm-dtest-api" "cassandra-harry" "cassandra-builds" "cassandra-website" "cassandra-java-driver" "cassandra-gocql-driver" "cassandra-sidecar" "cassandra-analytics" "cassandra-accord")
+      groupings=($(for repo in "${repos[@]}"; do basename "${repo}" .git ; done))
       ;;
     esac
 


### PR DESCRIPTION
I made the mistake in https://github.com/apache/cassandra-builds/commit/45c5b42649e9d929812e9b9c94d04b7ac8ef1308
of not also adding the new repositories to the wildcard groupings.

This removes the possibility of such mistake again.