### PR TITLE
CASSANDRA-20672 - release scripts should allow skipping the changelog update

### DIFF
--- a/cassandra-release/finish_release.sh
+++ b/cassandra-release/finish_release.sh
@@ -36,6 +36,7 @@ OPTIND=1
 # Initialize our own variables:
 verbose=0
 fake_mode=0
+skip_changelog=0
 
 show_help()
 {
@@ -45,6 +46,7 @@ show_help()
     echo "where [options] are:"
     echo "  -h: print this help"
     echo "  -v: verbose mode (show everything that is going on)"
+    echo "  -s: skip changelog update (for retrying failed releases)"
     echo "  -f: fake mode, print any output but don't do anything (for debugging)"
     echo ""
     echo "Example: $name 2.0.3"

--- a/cassandra-release/prepare_release.sh
+++ b/cassandra-release/prepare_release.sh
@@ -63,7 +63,7 @@ show_help()
     echo "Example: $name 2.0.3"
 }
 
-while getopts ":hvfdr" opt; do
+while getopts ":hvfdrs" opt; do
     case "$opt" in
     h)
         show_help
@@ -77,6 +77,8 @@ while getopts ":hvfdr" opt; do
         ;;
     r)  only_rpm=1
         ;;
+    s)  skip_changelog=1
+        ;;
     \?)
         echo "Invalid option: -$OPTARG" >&2
         show_help
@@ -88,6 +90,18 @@ done
 if [ $only_deb -eq 1 ] && [ $only_rpm -eq 1 ]
 then
     echo "Options '-d' and '-r' are mutually exclusive"
+    exit 1
+fi
+
+# The -s flag only makes sense during the full release flow
+if [ $skip_changelog -eq 1 ] && [ $only_deb -eq 1 ]
+then
+    echo "Option '-s' cannot be used with '-d'"
+    exit 1
+fi
+if [ $skip_changelog -eq 1 ] && [ $only_rpm -eq 1 ]
+then
+    echo "Option '-s' cannot be used with '-r'"
     exit 1
 fi
 
@@ -228,13 +242,18 @@ release_minor=$(echo ${release_short} | cut -d '.' -f 2)
 
 if [ $only_deb -eq 0 ] && [ $only_rpm -eq 0 ]
 then
-    echo "Update debian changelog, please correct changelog, name, and email."
-    read -n 1 -s -r -p "press any key to continue…" 1>&3 2>&4
-    echo ""
-    execute "dch -r -D unstable"
-    echo "Prepare debian changelog for $release" > "_tmp_msg_"
-    execute "git commit -F _tmp_msg_ debian/changelog"
-    execute "rm _tmp_msg_"
+    if [ $skip_changelog -eq 0 ]
+    then
+        echo "Update debian changelog, please correct changelog, name, and email."
+        read -n 1 -s -r -p "press any key to continue…" 1>&3 2>&4
+        echo ""
+        execute "dch -r -D unstable"
+        echo "Prepare debian changelog for $release" > "_tmp_msg_"
+        execute "git commit -F _tmp_msg_ debian/changelog"
+        execute "rm _tmp_msg_"
+    else
+        echo "Skipping changelog update (already committed)"
+    fi
     head_commit=`git log --pretty=oneline -1 | cut -d " " -f 1`
     # this commit needs to be forward merged and atomic pushed (see reminders at bottom)
 


### PR DESCRIPTION
**Problem**

When `prepare_release.sh` fails partway through, retrying requires manually commenting out the `dch` command in the script. The changelog update and git commit cannot be undone cleanly, making retries awkward.

**Solution**

Add a `-s` (skip changelog) flag that allows skipping the Debian changelog update step. This enables safe retries of failed releases without manual script editing or git history manipulation.

**Changes**

*   Add `-s` flag to command-line options
*   Add `skip_changelog` variable to track flag state
*   Wrap the `dch` execution and `git commit` in a conditional check
*   Add validation to prevent `-s` from being used with partial builds ( `-d` or `-r` )
*   Update help text to document the new flag